### PR TITLE
Make debugsp work again

### DIFF
--- a/.github/workflows/build-ssp.container.yaml
+++ b/.github/workflows/build-ssp.container.yaml
@@ -13,23 +13,23 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: ./docker
           platforms: linux/amd64,linux/arm64

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/container-files/simplesaml/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /container-files/simplesaml/
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,36 @@
 # OpenConect-devssp
 
-This repo contains all files which are needed to get a SimpleSAMLPHP docker container which contains development specific configuration.
+This repo contains all files that are needed to get a SimpleSAMLphp based SAML IdP and SP running in a docker container with a configuration that can be used to test OpenConext-Stepup.
 
 This container is not in any way production ready! It is meant for development purposes only. 
 
 The container is used in the docker-compose of the OpenConect-devconf project
+
+# Docker-compose
+To run the devssp using the docker-compose.yaml from the OpenConext-devconf project:
+
+- Clone the [OpenConext-devconf](https://github.com/OpenConext/OpenConext-devconf) project on the same level as this project. I.e. the directory structure should look like this:
+    ```
+    .
+    ├── OpenConext-devssp
+    └── OpenConext-devssp
+    ```
+- Ensure that ports 80 and 443 are available on the host
+- Add the following to your `/etc/hosts` file:
+    ```
+    127.0.0.1 ssp.dev.openconext.local
+    ```  
+
+- Start the container from the root of OpenConext-devssp. You can use the `./dev-start.sh` script or run the following command:
+
+  ```bash
+  docker compose up
+  ```
+  
+- ./dev-rebuild.sh will rebuild the container and pull the latest base image
+
+Both the ./dev-start.sh and ./dev-rebuild.sh scripts will copy the simplesaml directory from the contain to ./container-files on your hosts. This way you can use xdebug with the actual source files from the container by setting op a local path mapping in your IDE. 
+
+Then go to [https://ssp.dev.openconext.local/](https://ssp.dev.openconext.local/). The proxy uses a self-signed certificate, so you will need to accept this certificate in your browser.
+
+

--- a/container-files/scripts/sync.sh
+++ b/container-files/scripts/sync.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Use rsync to sync the SSP installation directory in /var/www/simplesaml to /simplesaml/
+# This is done to make the files from the container available on the host machine
+
+# check if rsync is installed, if not use apt to install it
+if ! command -v rsync &> /dev/null
+then
+    echo "rsync could not be found, installing rsync..."
+    apt-get update
+    apt-get install -y rsync
+fi
+
+# rsync from /var/www/simplesaml to /simplesaml, delete any files in /simplesaml that are not in /var/www/simplesaml
+rsync -av --delete /var/www/simplesaml/ /simplesaml/

--- a/dev-rebuild.sh
+++ b/dev-rebuild.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -e
+
+# This script will rebuild / pull Docker the docker images
+# then recreate and start the Docker containers
+
+# get the directory of this script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Verify that the ../OpenConext-devconf/stepup/ssp directory exists relative to this directory
+if [ ! -d "$DIR/../OpenConext-devconf/stepup/ssp" ]; then
+    echo "The directory $DIR/../OpenConext-devconf/stepup/ssp does not exist. Please clone the OpenConext-devconf repository."
+    exit 1
+fi
+
+docker compose build --no-cache --pull
+
+# Bring the containers up and wait for them to be ready
+docker compose up --force-recreate -d --wait
+
+# execute the sync script in the ssp container
+echo "Syncing the SSP installation directory to the host"
+docker compose exec -it ssp /scripts/sync.sh
+echo "Syncing done"
+
+# Attach to the containers's log output
+docker compose logs -f

--- a/dev-start.sh
+++ b/dev-start.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e
+
+# get the directory of this script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Verify that the ../OpenConext-devconf/stepup/ssp directory exists relative to this directory
+if [ ! -d "$DIR/../OpenConext-devconf/stepup/ssp" ]; then
+    echo "The directory $DIR/../OpenConext-devconf/stepup/ssp does not exist. Please clone the OpenConext-devconf repository."
+    exit 1
+fi
+
+# This script will start the Docker containers, rebuild the images
+# The  --force-recreate  flag will recreate the containers even if they are already running.
+# The  --build  flag will rebuild the devssp image
+
+echo "Rebuilding the devssp image and starting the containers..."
+docker compose up --force-recreate --build -d --wait
+echo "Containers are up"
+
+# execute the sync script in the container
+echo "Syncing the SSP installation directory to the host"
+docker compose exec -it ssp /scripts/sync.sh
+echo "Syncing done"
+
+# attach to the containers's log output
+docker compose logs -f
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,33 @@
+services:
+  haproxy:
+    image: ghcr.io/openconext/openconext-basecontainers/haproxy26:latest
+    ports:
+      - "80:80"
+      - "443:443"
+    networks:
+      devsp_network:
+        aliases:
+          - ssp.dev.openconext.local
+    hostname: haproxy.docker
+
+  ssp:
+    build: ./docker/
+    hostname: ssp.docker
+    networks:
+      devsp_network:
+    volumes:
+      # Make the ssp configuration from OpenConext-devconf available in the container
+      - ./../OpenConext-devconf/stepup/ssp:/var/www/simplesaml/config/cert/
+
+      # A copy of the /var/www/simplesaml/ directory to make this available to the host
+      - ./container-files/simplesaml:/simplesaml/
+
+      # Contains the sync script that is used to make the copy.
+      - ./container-files/scripts:/scripts/
+
+networks:
+  # create a local only network for the devssp container
+  devsp_network:
+    driver: bridge
+
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,10 +5,9 @@ FROM ghcr.io/openconext/openconext-basecontainers/php82-apache2-node20-composer2
 # https://github.com/OpenConext/OpenConext-BaseContainers/blob/main/php82-apache2/Dockerfile
 # Exposes PORT 80 for apache
 
-
 LABEL maintainer="pieter.vandermeulen@surf.nl"
 WORKDIR /var/www/simplesaml
-RUN curl -L "https://github.com/simplesamlphp/simplesamlphp/releases/download/v2.1.1/simplesamlphp-2.1.1.tar.gz" | tar -xvz -C /var/www/simplesaml --strip-components=1
+RUN curl -L "https://github.com/simplesamlphp/simplesamlphp/releases/download/v2.1.2/simplesamlphp-2.1.2.tar.gz" | tar -xvz -C /var/www/simplesaml --strip-components=1
 COPY ./modules/ /var/www/simplesaml/my-modules/
 COPY ./html/* /var/www/html
 COPY ./sspwww/* /var/www/simplesaml/public/ 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,24 @@
-FROM ghcr.io/openconext/openconext-basecontainers/php80-apache2:latest 
-COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
-LABEL maintainer="bart.geesink@surf.nl"
+FROM ghcr.io/openconext/openconext-basecontainers/php82-apache2-node20-composer2:latest
+# See:
+# https://github.com/OpenConext/OpenConext-BaseContainers/blob/main/php82-apache2-node20-composer2/Dockerfile
+
+# https://github.com/OpenConext/OpenConext-BaseContainers/blob/main/php82-apache2/Dockerfile
+# Exposes PORT 80 for apache
+
+
+LABEL maintainer="pieter.vandermeulen@surf.nl"
 WORKDIR /var/www/simplesaml
-RUN curl -L "https://github.com/simplesamlphp/simplesamlphp/releases/download/v2.0.4/simplesamlphp-2.0.4.tar.gz" | tar -xvz -C /var/www/simplesaml --strip-components=1 && \
-  /usr/bin/composer require simplesamlphp/simplesamlphp-module-saml2debug --no-update
+RUN curl -L "https://github.com/simplesamlphp/simplesamlphp/releases/download/v2.1.1/simplesamlphp-2.1.1.tar.gz" | tar -xvz -C /var/www/simplesaml --strip-components=1
+COPY ./modules/ /var/www/simplesaml/my-modules/
+COPY ./html/* /var/www/html
 COPY ./sspwww/* /var/www/simplesaml/public/ 
 COPY ./sspconf/ /var/www/simplesaml/config/
 COPY ./sspattributemap/Openconext_short_to_urn.php /var/www/simplesaml/attributemap/
 COPY ./conf/000-default.conf /etc/apache2/sites-enabled/
+
+# Install the debugsp module from local source code.
+# First add the local directory with the module's source code to the composer repositories.
+RUN composer config repositories.debugsp path /var/www/simplesaml/my-modules/debugsp
+
+# Use composer to install the module so that the simplesamlphp/composer-module-installer can do its thing.
+RUN COMPOSER_ALLOW_SUPERUSER=1 COMPOSER_MIRROR_PATH_REPOS=1 composer require pmeulen/simplesamlphp-module-debugsp:dev-main

--- a/docker/conf/000-default.conf
+++ b/docker/conf/000-default.conf
@@ -1,4 +1,6 @@
-<VirtualHost *:80>
+ServerName ssp.dev.openconext.local
+
+<VirtualHost *:80> 
    ServerAdmin webmaster@localhost
    DocumentRoot /var/www/html
    ErrorLog ${APACHE_LOG_DIR}/error.log

--- a/docker/html/index.html
+++ b/docker/html/index.html
@@ -1,0 +1,33 @@
+<html>
+<head>
+    <title>OpenConext SimpleSAMLphp test container - ssp.dev.openconext.local</title>
+</head>
+<h2>OpenConext SimpleSAMLphp test container - ssp.dev.openconext.local</h2>
+
+<h3>Service Provider</h3>
+<ul>
+    <li><a href="https://ssp.dev.openconext.local/simplesaml/sp.php">Test SP</a></li>
+</ul>
+
+<h3>SAML Metadata</h3>
+<ul>
+    <li>SAML 2.0 IdP Metadata: <a href="https://ssp.dev.openconext.local/simplesaml/saml2/idp/metadata.php"><code>https://ssp.dev.openconext.local/simplesaml/saml2/idp/metadata.php</code></a></li>
+    <li>SAML 2.0 SP Metadata - default-sp: <a href="https://ssp.dev.openconext.local/simplesaml/module.php/saml/sp/metadata.php/default-sp"><code>https://ssp.dev.openconext.local/simplesaml/module.php/saml/sp/metadata.php/default-sp</code></a></li>
+    <li>SAML 2.0 SP Metadata - second-sp: <a href="https://ssp.dev.openconext.local/simplesaml/module.php/saml/sp/metadata.php/second-sp"><code>https://ssp.dev.openconext.local/simplesaml/module.php/saml/sp/metadata.php/second-sp</code></a></li>
+    <li>SAML 2.0 SP Metadata - third-sp: <a href="https://ssp.dev.openconext.local/simplesaml/module.php/saml/sp/metadata.php/third-sp"><code>https://ssp.dev.openconext.local/simplesaml/module.php/saml/sp/metadata.php/third-sp</code></a></li>
+    <li>SAML 2.0 SP Metadata - fourth-sp: <a href="https://ssp.dev.openconext.local/simplesaml/module.php/saml/sp/metadata.php/fourth-sp"><code>https://ssp.dev.openconext.local/simplesaml/module.php/saml/sp/metadata.php/fourth-sp</code></a></li>
+</ul>
+
+<h3>SimpleSAMLphp</h3>
+<ul>
+    <li><a href="https://ssp.dev.openconext.local/simplesaml/admin">SimpleSAMLphp installation page (password: <code>secret</code>)</a></li>    
+</ul>
+
+<h3>Test accounts</h3>
+
+The following test accounts are available:
+
+... TODO ...
+
+</body>
+</html>

--- a/docker/html/index.html
+++ b/docker/html/index.html
@@ -2,6 +2,7 @@
 <head>
     <title>OpenConext SimpleSAMLphp test container - ssp.dev.openconext.local</title>
 </head>
+<body>
 <h2>OpenConext SimpleSAMLphp test container - ssp.dev.openconext.local</h2>
 
 <h3>Service Provider</h3>
@@ -25,9 +26,95 @@
 
 <h3>Test accounts</h3>
 
-The following test accounts are available:
+For all test accounts, the username is equal to the password. The account <code>admin</code> is intended as a pre-provisioned superuser account.
 
-... TODO ...
+The other accounts are generated based on a pattern consisting of the parts:
+<ol>
+    <li>a <b>prefix</b> (username)</li>
+    <li>an <b>institution</b> (organisation) identifier</li>
+    <li>a <b>suffix</b> with an account number or role, these are meant as a mnemonic and do not change the behaviour of the account/</li>
+</ol>
+
+<p>See below available prefixes, institutions and suffixes. A test account is created for each combination of prefix, institution and suffix.
+Pay attention to the hyphens in the suffixes, 1-5 do not have them, the other suffixes do.</p>
+<p>Examples: <code>joe-a1</code>, <code>jane-b2</code>, <code>user-d4</code>, <code>jane-a-raa</code>, <code>joe-e-ra</code>, <code>user-d-tiqr</code></p>
+
+<h4>Prefixes</h4>
+<ul>
+    <li><code>user-</code></li>
+    <li><code>joe-</code></li>
+    <li><code>jane-</code></li>
+</ul>
+
+<h4>Institutions</h4>
+
+Institutions are identified by a one-letter code, each institution has a schacHomeOrganisation.
+<table>
+    <tr>
+        <th>Code</th>
+        <th>schacHomeOrganisation</th>
+    </tr>
+    <tr>
+        <td><code>a</code></td>
+        <td>institution-<b>a</b>.example.com</td>
+    </tr>
+    <tr>
+        <td><code>b</code></td>
+        <td>institution-<b>b</b>.example.com</td>
+    </tr>
+    <tr>
+        <td><code>c</code></td>
+        <td>institution-<b>c</b>.example.com</td>
+    </tr>
+    <tr>
+        <td><code>d</code></td>
+        <td>Institution-<b>D</b>.EXAMPLE.COM</td>
+    </tr>
+    <tr>
+        <td><code>e</code></td>
+        <td>institution-<b>e</b>.example.com</td>
+    </tr>
+    <tr>
+        <td><code>f</code></td>
+        <td>institution-<b>f</b>.example.com</td>
+    </tr>
+</table>
+
+<h4>Suffixes</h4>
+<table>
+    <tr>
+        <th>Suffix</th>
+        <th>Description</th>
+    </tr>
+    <tr>
+        <td><code>1</code>, <code>2</code>, ... <code>5</code></td>
+        <td>generic user accounts</td>
+    </tr>
+    <tr>
+        <td><code>-sms</code></td>
+        <td>User with an SMS token</td>
+    </tr>
+    <tr>
+        <td><code>-yk</code></td>
+        <td>User with a Yubikey token</td>
+    </tr>
+    <tr>
+        <td><code>-tiqr</code></td>
+        <td>User with a Tiqr token</td>
+    </tr>
+    <tr>
+        <td><code>-u2f</code></td>
+        <td>User with a U2F / FIDO / WebAuthn token</td>
+    </tr>
+    <tr>
+        <td><code>-ra</code></td>
+        <td>User with a registration authority role</td>
+    </tr>
+    <tr>
+        <td><code>-raa</code></td>
+        <td>User with a registration authority administrator role</td>
+    </tr>
+</table>
 
 </body>
 </html>

--- a/docker/modules/debugsp/composer.json
+++ b/docker/modules/debugsp/composer.json
@@ -1,0 +1,21 @@
+{
+  "name": "pmeulen/simplesamlphp-module-debugsp",
+  "description": "This modules extends the SSP SAML SP",
+  "license": "Apache-2.0",
+  "authors": [
+    {
+      "name": "Pieter van der Meulen",
+      "email": "pieter.vandermeulen@surf.nl"
+    }
+  ],
+  "type": "simplesamlphp-module",
+  "require": {
+    "simplesamlphp/composer-module-installer": "^1.3",
+    "simplesamlphp/simplesamlphp": "^2.1"
+  },
+  "autoload": {
+    "psr-4": {
+      "SimpleSAML\\Module\\debugsp\\": "src/"
+    }
+  }
+}

--- a/docker/modules/debugsp/routing/routes/routes.yaml
+++ b/docker/modules/debugsp/routing/routes/routes.yaml
@@ -1,0 +1,18 @@
+---
+
+# Routes for the debugsp module.
+# paths are relative to the module base path. I.e. <baseurlpath>/module.php/debugsp/
+
+debug-sp-assertionConsumerService:
+  path: /acs/{sourceId}
+  defaults: {
+    _controller: 'SimpleSAML\Module\debugsp\Controller\ServiceProvider::assertionConsumerService'
+  }
+  methods: [GET, POST]
+
+debug-sp-metadata:
+  path: /metadata/{sourceId}
+  defaults: {
+    _controller: 'SimpleSAML\Module\debugsp\Controller\ServiceProvider::metadata'
+  }
+  methods: [GET]

--- a/docker/modules/debugsp/src/Auth/Source/SP.php
+++ b/docker/modules/debugsp/src/Auth/Source/SP.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace SimpleSAML\Module\debugsp\Auth\Source;
+
+use SAML2\Request;
+use SimpleSAML\Assert\Assert;
+use SimpleSAML\Configuration;
+use SimpleSAML\Logger;
+use SAML2\AuthnRequest;
+use SAML2\Binding;
+use SAML2\HTTPPost;
+use SAML2\Utils;
+use SimpleSAML\Module;
+
+
+/*  Usage:
+   - In authsourcesphp use "debugsp:SP" where you would otherwise use "saml:SP"
+   - In the call to AuthSimple::requireAuth($params), AuthSimple::login($params) set 'debugsp:AssertionConsumerServiceURL'
+     and 'debugsp:extraPOSTvars' to the desired values.
+     E.g.:
+     $params=array(
+        'debugsp:AssertionConsumerServiceURL' => 'https://...',
+        'debugsp:extraPOSTvars' => array(
+           'SomePOSTvariable'    => 'SomeValue',
+           'AnotherPOSTvariable' => 'AnotherValue'
+        ),
+     );
+     $as->login($params);
+*/
+
+// Extend from the SimpleSAMLphp SAML 2.0 authentication source "saml:SP"
+// (see: <SimpleSAMLphp>/modules/saml/src/Auth/Source/SP.php)
+
+class SP extends \SimpleSAML\Module\saml\Auth\Source\SP
+{
+
+    private $state;
+
+    public function __construct($info, $config)
+    {
+        Logger::debug('debugsp: debugsp\Auth\Source\SP::__construct(...)');
+        // Get moduleURL of this module
+        $moduleURL = \SimpleSAML\Module::getModuleURL('debugsp');
+        Logger::debug("debugsp: ModuleURL: $moduleURL");
+        $moduleDir = \SimpleSAML\Module::getModuleDir('debugsp');
+        Logger::debug("debugsp: ModuleDir: $moduleDir");
+
+        parent::__construct($info, $config);
+    }
+
+
+    public function startSSO(string $idp, array $state): void
+    {
+        $state_json = json_encode($state);
+        Logger::debug("debugsp\Auth\Source\SP::startSSO('$idp', $state_json)");
+        // The sequence for an authentication is:
+        // - authenticate(&state: array)
+        // - startSSO(string $idp, array $state)
+        // - startSSO2() (private)
+        // - sendSAML2AuthnRequest()
+
+        // We need $state in sendSAML2AuthnRequest() because it holds our options like: 'debugsp:AssertionConsumerServiceURL'
+        // and 'debugsp:extraPOSTvars'
+        // This solution is a bit hackish, but it should work just fine. It's the only simple way to pass the state to
+        // sendSAML2AuthnRequest(). We can't override startSSO2() because it's private.
+        // The other option would be to completely copy the parent's implementation of startSSO() and startSSO2()
+
+        // Store the state
+        Logger::debug('debugsp: storing state');
+
+        $this->state = $state;
+
+        // Call parent's implementation
+        parent::startSSO($idp, $state);
+    }
+
+
+    // Override \SimpleSAML\Auth\Source\SP::sendSAML2AuthnRequest() to allow us to make last minute changes to the
+    // AuthnRequest before it is sent to the IdP
+    public function sendSAML2AuthnRequest(Binding $binding, AuthnRequest $ar): void
+    {
+        Logger::debug('debugsp: debugsp\Auth\Source\SP::sendSAML2AuthnRequest(...)');
+        if (isset($this->state['debugsp:AssertionConsumerServiceURL'])) {
+            Logger::notice('debugsp:AssertionConsumerServiceURL set to ' . $this->state['debugsp:AssertionConsumerServiceURL']);
+            // Set the AssertionConsumerServiceURL in the AuthnRequest
+            $acs = $this->state['debugsp:AssertionConsumerServiceURL'];
+            $ar->setAssertionConsumerServiceURL($acs);
+        }
+
+        if ($binding instanceof HTTPPost) {
+            Logger::debug('debugsp: binding is HTTPPost');
+            // Send a SAML AuthnRequest using to HTTP-POST binding
+            // replicate \SAML2\HTTPPost::send(Message $message) so we can set additional POST variables
+            $destination = $ar->getDestination();
+            $relayState = $ar->getRelayState();
+
+            $post = array();
+
+            // Set extra POST variables
+            if (isset($this->state['debugsp:extraPOSTvars'])) {
+                assert(is_array($this->state['debugsp:extraPOSTvars']), 'debugsp:extraPOSTvars must be array()');
+                foreach ($this->state['debugsp:extraPOSTvars'] as $key => $value) {
+                    $post[$key] = $value;
+                    Logger::info('debugsp:extraPOSTvars: ' . $key . ' => ' . $value);
+                }
+            }
+
+            // Create SAMLRequest and add it to the POST variables the standard way
+            $msgStr = $ar->toSignedXML();
+            Utils::getContainer()->debugMessage($msgStr, 'out');
+            $msgStr = $msgStr->ownerDocument->saveXML($msgStr);
+
+            $post['SAMLRequest'] = base64_encode($msgStr);
+
+            if ($relayState !== null) {
+                $post['RelayState'] = $relayState;
+            }
+
+            Logger::debug('debugsp: sending request using HTTP-POST binding');
+            Utils::getContainer()->postRedirect($destination, $post);
+
+            // Does not return
+            Assert::true(false);
+        }
+
+        // Use parent's implementation ( which is just: $binding->send($ar); )
+        Logger::debug('debugsp: sending authn request using parent implementation');
+        parent::sendSAML2AuthnRequest($binding, $ar);
+
+        // Does not return
+        Assert::true(false);
+    }
+
+    /**
+     * Retrieve the metadata of this SP.
+     *
+     * @return \SimpleSAML\Configuration  The metadata of this SP.
+     */
+    public function getMetadata(): Configuration
+    {
+        Logger::debug('debugsp: debugsp\Auth\Source\SP::getMetadata()');
+
+        $metadata = parent::getMetadata();
+
+        return $metadata;
+    }
+
+    public function getMetadataURL(): string
+    {
+        Logger::debug('debugsp: debugsp\Auth\Source\SP::getMetadataURL()');
+
+        // Create URL that matches our route: debug-sp-metadata
+        return Module::getModuleURL('debugsp/metadata/' . urlencode($this->authId));
+    }
+
+    /**
+     * Retrieve the metadata array of this SP, as a remote IdP would see it.
+     *
+     * @return array The metadata array for its use by a remote IdP.
+     */
+    public function getHostedMetadata(): array
+    {
+        Logger::debug('debugsp: debugsp\Auth\Source\SP::getHostedMetadata()');
+
+        $metadata = parent::getHostedMetadata();
+
+        // Override the AssertionConsumerService URL in the metadata to our own ACL URL to we can catch it
+
+        // Create URL that matches our route: debug-sp-assertionConsumerService
+        $acsLocation = Module::getModuleURL('debugsp/acs/') . urlencode($this->authId);
+        foreach ($metadata['AssertionConsumerService'] as $key => $acs) {
+            switch ($metadata['AssertionConsumerService'][$key]['Binding']) {
+                case 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST':
+                case 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect':
+                    Logger::debug("debugsp: setting AssertionConsumerService Location of binding $key to $acsLocation");
+                    $metadata['AssertionConsumerService'][$key]['Location'] = $acsLocation;
+            }
+        }
+        return $metadata;
+    }
+}

--- a/docker/modules/debugsp/src/Controller/ServiceProvider.php
+++ b/docker/modules/debugsp/src/Controller/ServiceProvider.php
@@ -1,0 +1,61 @@
+<?php
+
+#declare(strict_types=1);
+
+namespace SimpleSAML\Module\debugsp\Controller;
+
+use SimpleSAML\Logger;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use SimpleSAML\HTTP\RunnableResponse;
+
+class ServiceProvider extends \SimpleSAML\Module\saml\Controller\ServiceProvider
+{
+    public function __construct(
+        protected \SimpleSAML\Configuration $config,
+        protected \SimpleSAML\Session $session
+    ) {
+        Logger::info('debugsp\Controller\ServiceProvider::__construct()');
+
+        parent::__construct($config, $session);
+    }
+
+    /**
+     * Handler for the Assertion Consumer Service.
+     *
+     * @param string $sourceId
+     * @return \SimpleSAML\HTTP\RunnableResponse
+     */
+    public function assertionConsumerService(string $sourceId): RunnableResponse
+    {
+        Logger::info("debugsp\Controller\ServiceProvider::assertionConsumerService($sourceId)");
+
+        // Rename the "_SAMLResponse" variable that used by the ADFS SFO extension back to the SAML HTTP-POST standard
+        // "SAMLResponse" and then hand over processing to the standard SSP ACS processing
+
+        if (isset($_POST['_SAMLResponse'])) {
+            // Make ADFS response look like a normal SAML response
+            Logger::info("Renaming '_SAMLResponse' to 'SAMLResponse'");
+            $_POST['SAMLResponse'] = $_POST['_SAMLResponse'];
+        }
+
+        // Let parent handle the response
+        return parent::assertionConsumerService($sourceId);
+    }
+
+
+    /**
+     * Metadata endpoint for SAML SP
+     *
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param string $sourceId
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function metadata(Request $request, string $sourceId): Response
+    {
+        Logger::info("debugsp\Controller\ServiceProvider::metadata($sourceId)");
+
+        // Let parent handle the response
+        return parent::metadata($request, $sourceId);
+    }
+}

--- a/docker/sspattributemap/Openconext_short_to_urn.php
+++ b/docker/sspattributemap/Openconext_short_to_urn.php
@@ -16,6 +16,8 @@ $attributemap = array(
     // urn:mace:terena.org
 	'schacHomeOrganization'		=> 'urn:mace:terena.org:attribute-def:schacHomeOrganization',
 	'schacHomeOrganizationType'	=> 'urn:mace:terena.org:attribute-def:schacHomeOrganizationType',
+
+	'NameID'					=> 'urn:mace:surf.nl:attribute-def:internal-collabPersonId',
 );
 
 ?>

--- a/docker/sspconf/authsources.php
+++ b/docker/sspconf/authsources.php
@@ -34,34 +34,6 @@ $config = array(
             'schacHomeOrganizationType' => 'urn:mace:terena.org:schac:homeOrganizationType:int:university',
         ),
 
-        'pieter:pieter' => array(
-            'NameID' => 'urn:collab:person:dev.openconext.local:pieter',
-            'uid' => array('pieter'),
-            'mail' => 'pieter.vanderMeulen@surfnet.nl',
-            'eduPersonPrincipalName' => 'pieter@dev.openconext.local',
-            'givenName' => 'Pieter',
-            'sn' => 'van der Meulen',
-            'cn' => 'Pieter van der Meulen',
-            'displayName' => 'Pieter van der Meulen',
-            'eduPersonAffiliation' => array('employee'),
-            'schacHomeOrganization' => 'dev.openconext.local',
-            'schacHomeOrganizationType' => 'urn:mace:terena.org:schac:homeOrganizationType:int:NREN',
-        ),
-
-        'joost:joost' => array(
-            'NameID' => 'urn:collab:person:dev.openconext.local:joost',
-            'uid' => array('joost'),
-            'mail' => 'joost.vanDijk@surfnet.nl',
-            'eduPersonPrincipalName' => 'joost@dev.openconext.local',
-            'givenName' => 'Joost',
-            'sn' => 'van Dijk',
-            'cn' => 'Joost van Dijk',
-            'displayName' => 'Joost van Dijk',
-            'eduPersonAffiliation' => array('employee'),
-            'schacHomeOrganization' => 'dev.openconext.local',
-            'schacHomeOrganizationType' => 'urn:mace:terena.org:schac:homeOrganizationType:int:NREN',
-        ),
-
         // Test accounts are added using account_gen below
 
     ),
@@ -69,7 +41,7 @@ $config = array(
     // An authentication source which can authenticate against both SAML 2.0
     // and Shibboleth 1.3 IdPs.
     'default-sp' => array(
-        'saml:SP',
+        'debugsp:SP',
 
         // The entity ID of this SP.
         // Can be NULL/unset, in which case an entity ID is generated based on the metadata URL.
@@ -89,7 +61,7 @@ $config = array(
         // See end of file for request.sign and signature alg config!
     ),
     'second-sp' => array(
-        'saml:SP',
+        'debugsp:SP',
 
         // The entity ID of this SP.
         // Can be NULL/unset, in which case an entity ID is generated based on the metadata URL.
@@ -111,7 +83,7 @@ $config = array(
         //'signature.algorithm' => 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
     ),
     'third-sp' => array(
-        'saml:SP',
+        'debugsp:SP',
 
         // The entity ID of this SP.
         // Can be NULL/unset, in which case an entity ID is generated based on the metadata URL.
@@ -133,7 +105,7 @@ $config = array(
         //'signature.algorithm' => 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
     ),
     'fourth-sp' => array(
-        'saml:SP',
+        'debugsp:SP',
 
         // The entity ID of this SP.
         // Can be NULL/unset, in which case an entity ID is generated based on the metadata URL.
@@ -212,11 +184,11 @@ $slugs=array(
 // For all accounts the username is equal to the password. E.g. "joe-a1" / "joe-a1"
 foreach ($accounts as $user => $email) {
     //                   username   , email,  schachomeorganization
-    account_gen($config, "${user}-",  $email, 'dev.openconext.local', $slugs);
-    account_gen($config, "${user}-a", $email, 'institution-a.example.com', $slugs);
-    account_gen($config, "${user}-b", $email, 'institution-b.example.com', $slugs);
-    account_gen($config, "${user}-c", $email, 'institution-c.example.com', $slugs);
-    account_gen($config, "${user}-d", $email, 'Institution-D.EXAMPLE.COM', $slugs); // Note: uppercase "I" and "D"
-    account_gen($config, "${user}-e", $email, 'Institution-e.example.com', $slugs);
-    account_gen($config, "${user}-f", $email, 'Institution-f.example.com', $slugs);
+    account_gen($config, "{$user}-",  $email, 'dev.openconext.local', $slugs);
+    account_gen($config, "{$user}-a", $email, 'institution-a.example.com', $slugs);
+    account_gen($config, "{$user}-b", $email, 'institution-b.example.com', $slugs);
+    account_gen($config, "{$user}-c", $email, 'institution-c.example.com', $slugs);
+    account_gen($config, "{$user}-d", $email, 'Institution-D.EXAMPLE.COM', $slugs); // Note: uppercase "I" and "D"
+    account_gen($config, "{$user}-e", $email, 'Institution-e.example.com', $slugs);
+    account_gen($config, "{$user}-f", $email, 'Institution-f.example.com', $slugs);
 }

--- a/docker/sspconf/authsources.php
+++ b/docker/sspconf/authsources.php
@@ -175,7 +175,7 @@ $accounts=array(
 
 // List of varieties of account to generate
 $slugs=array(
-    "1", "2", "3", "4", "5", "sms", "-yk", "-tiqr", "-u2f", "-bio", "-ra", "-raa"
+    "1", "2", "3", "4", "5", "-sms", "-yk", "-tiqr", "-u2f", "-ra", "-raa"
 );
 
 // for a username 'joe' this will generate joe-a1, joe-a2, ..., joe-a-yk, ... joe-a-raa

--- a/docker/sspconf/config.php
+++ b/docker/sspconf/config.php
@@ -8,72 +8,827 @@ $httpUtils = new \SimpleSAML\Utils\HTTP();
 
 $config = [
 
-  'baseurlpath' => 'https://ssp.dev.openconext.local/simplesaml/',
-  'baseurl' => 'https://dev.ssp.openconext.local/simplesaml/',
+    /*******************************
+     | BASIC CONFIGURATION OPTIONS |
+     *******************************/
+
+    /*
+     * Setup the following parameters to match your installation.
+     * See the user manual for more details.
+     */
+
+    /*
+     * baseurlpath is a *URL path* (not a filesystem path).
+     * A valid format for 'baseurlpath' is:
+     * [(http|https)://(hostname|fqdn)[:port]]/[path/to/simplesaml/]
+     *
+     * The full url format is useful if your SimpleSAMLphp setup is hosted behind
+     * a reverse proxy. In that case you can specify the external url here.
+     * Specifying the full URL including https: will let SimpleSAMLphp know
+     * that it runs on HTTPS even if the backend server is plain HTTP.
+     *
+     * Please note that SimpleSAMLphp will then redirect all queries to the
+     * external url, no matter where you come from (direct access or via the
+     * reverse proxy).
+     */
+    //'baseurlpath' => 'simplesaml/',
+    'baseurlpath' => 'https://ssp.dev.openconext.local/simplesaml/',    
+
+    /*
+     * The 'application' configuration array groups a set configuration options
+     * relative to an application protected by SimpleSAMLphp.
+     */
+    'application' => [
+        /*
+         * The 'baseURL' configuration option allows you to specify a protocol,
+         * host and optionally a port that serves as the canonical base for all
+         * your application's URLs. This is useful when the environment
+         * observed in the server differs from the one observed by end users,
+         * for example, when using a load balancer to offload TLS.
+         *
+         * Note that this configuration option does not allow setting a path as
+         * part of the URL. If your setup involves URL rewriting or any other
+         * tricks that would result in SimpleSAMLphp observing a URL for your
+         * application's scripts different than the canonical one, you will
+         * need to compute the right URLs yourself and pass them dynamically
+         * to SimpleSAMLphp's API.
+         */
+        //'baseURL' => 'https://example.com',
+    ],
+
+    /*
+     * The following settings are *filesystem paths* which define where
+     * SimpleSAMLphp can find or write the following things:
+     * - 'loggingdir': Where to write logs. MUST be set to NULL when using a logging
+     *                 handler other than `file`.
+     * - 'datadir': Storage of general data.
+     * - 'tempdir': Saving temporary files. SimpleSAMLphp will attempt to create
+     *   this directory if it doesn't exist.
+     * When specified as a relative path, this is relative to the SimpleSAMLphp
+     * root directory.
+     */
+    //'loggingdir' => '/var/log/',
     'loggingdir' => null,
-    'datadir' => 'data/',
+    //'datadir' => '/var/data/',
     'tempdir' => '/tmp/simplesaml',
-    'certdir' => 'config/cert/',
+
+    /*
+     * Certificate and key material can be loaded from different possible
+     * locations. Currently two locations are supported, the local filesystem
+     * and the database via pdo using the global database configuration. Locations
+     * are specified by a URL-link prefix before the file name/path or database
+     * identifier.
+     */
+
+    /* To load a certificate or key from the filesystem, it should be specified
+     * as 'file://<name>' where <name> is either a relative filename or a fully
+     * qualified path to a file containing the certificate or key in PEM
+     * format, such as 'cert.pem' or '/path/to/cert.pem'. If the path is
+     * relative, it will be searched for in the directory defined by the
+     * 'certdir' parameter below. When 'certdir' is specified as a relative
+     * path, it will be interpreted as relative to the SimpleSAMLphp root
+     * directory. Note that locations with no prefix included will be treated
+     * as file locations.
+     */
+    //'certdir' => 'cert/',
+    'certdir' => '/var/www/simplesaml/config/cert/',
+
+    /* To load a certificate or key from the database, it should be specified
+     * as 'pdo://<id>' where <id> is the identifier in the database table that
+     * should be matched. While the certificate and key tables are expected to
+     * be in the simplesaml database, they are not created or managed by
+     * simplesaml. The following parameters control how the pdo location
+     * attempts to retrieve certificates and keys from the database:
+     *
+     * - 'cert.pdo.table': name of table where certificates are stored
+     * - 'cert.pdo.keytable': name of table where keys are stored
+     * - 'cert.pdo.apply_prefix': whether or not to prepend the database.prefix
+     *                            parameter to the table names; if you are using
+     *                            database.prefix to separate multiple SSP instances
+     *                            in the same database but want to share certificate/key
+     *                            data between them, set this to false
+     * - 'cert.pdo.id_column': name of column to use as identifier
+     * - 'cert.pdo.data_column': name of column where PEM data is stored
+     *
+     * Basically, the query executed will be:
+     *
+     *   SELECT cert.pdo.data_column FROM cert.pdo.table WHERE cert.pdo.id_column = :id
+     *
+     * Defaults are shown below, to change them, uncomment the line and update as
+     * needed
+     */
+    //'cert.pdo.table' => 'certificates',
+    //'cert.pdo.keytable' => 'private_keys',
+    //'cert.pdo.apply_prefix' => true,
+    //'cert.pdo.id_column' => 'id',
+    //'cert.pdo.data_column' => 'data',
+
+    /*
+     * Some information about the technical persons running this installation.
+     * The email address will be used as the recipient address for error reports, and
+     * also as the technical contact in generated metadata.
+     */
     'technicalcontact_name' => 'Tech Contact',
     'technicalcontact_email' => 'tech@dev.openconext.local',
+
+    /*
+     * (Optional) The method by which email is delivered.  Defaults to mail which utilizes the
+     * PHP mail() function.
+     *
+     * Valid options are: mail, sendmail and smtp.
+     */
+    //'mail.transport.method' => 'smtp',
+
+    /*
+     * Set the transport options for the transport method specified.  The valid settings are relative to the
+     * selected transport method.
+     */
+    /*
+    'mail.transport.options' => [
+        'host' => 'mail.example.org', // required
+        'port' => 25, // optional
+        'username' => 'user@example.org', // optional: if set, enables smtp authentication
+        'password' => 'password', // optional: if set, enables smtp authentication
+        'security' => 'tls', // optional: defaults to no smtp security
+        'smtpOptions' => [], // optional: passed to stream_context_create when connecting via SMTP
+    ],
+
+    // sendmail mail transport options
+    /*
+    'mail.transport.options' => [
+        'path' => '/usr/sbin/sendmail' // optional: defaults to php.ini path
+    ],
+    */
+
+    /*
+     * The envelope from address for outgoing emails.
+     * This should be in a domain that has your application's IP addresses in its SPF record
+     * to prevent it from being rejected by mail filters.
+     */
+    //'sendmail_from' => 'no-reply@example.org',
+
+    /*
+     * The timezone of the server. This option should be set to the timezone you want
+     * SimpleSAMLphp to report the time in. The default is to guess the timezone based
+     * on your system timezone.
+     *
+     * See this page for a list of valid timezones: http://php.net/manual/en/timezones.php
+     */
+    //'timezone' => null,
     'timezone' => 'Europe/Amsterdam',
+
+
+    /**********************************
+     | SECURITY CONFIGURATION OPTIONS |
+     **********************************/
+
+    /*
+     * This is a secret salt used by SimpleSAMLphp when it needs to generate a secure hash
+     * of a value. It must be changed from its default value to a secret value. The value of
+     * 'secretsalt' can be any valid string of any length.
+     *
+     * A possible way to generate a random salt is by running the following command from a unix shell:
+     * LC_ALL=C tr -c -d '0123456789abcdefghijklmnopqrstuvwxyz' </dev/urandom | dd bs=32 count=1 2>/dev/null;echo
+     */
+    //'secretsalt' => 'defaultsecretsalt',
     'secretsalt' => 'secret',
+
+    /*
+     * This password must be kept secret, and modified from the default value 123.
+     * This password will give access to the installation page of SimpleSAMLphp with
+     * metadata listing and diagnostics pages.
+     * You can also put a hash here; run "bin/pwgen.php" to generate one.
+     */
+    //'auth.adminpassword' => '123',
     'auth.adminpassword' => 'secret',
+
+    /*
+     * Set this option to true if you want to require administrator password to access the metadata.
+     */
     'admin.protectmetadata' => false,
-    'admin.checkforupdates' => true,
+
+    /*
+     * Set this option to false if you don't want SimpleSAMLphp to check for new stable releases when
+     * visiting the configuration tab in the web interface.
+     */
+    //'admin.checkforupdates' => true,
+    'admin.checkforupdates' => false,
+
+    /*
+     * Array of domains that are allowed when generating links or redirects
+     * to URLs. SimpleSAMLphp will use this option to determine whether to
+     * to consider a given URL valid or not, but you should always validate
+     * URLs obtained from the input on your own (i.e. ReturnTo or RelayState
+     * parameters obtained from the $_REQUEST array).
+     *
+     * SimpleSAMLphp will automatically add your own domain (either by checking
+     * it dynamically, or by using the domain defined in the 'baseurlpath'
+     * directive, the latter having precedence) to the list of trusted domains,
+     * in case this option is NOT set to NULL. In that case, you are explicitly
+     * telling SimpleSAMLphp to verify URLs.
+     *
+     * Set to an empty array to disallow ALL redirects or links pointing to
+     * an external URL other than your own domain. This is the default behaviour.
+     *
+     * Set to NULL to disable checking of URLs. DO NOT DO THIS UNLESS YOU KNOW
+     * WHAT YOU ARE DOING!
+     *
+     * Example:
+     *   'trusted.url.domains' => ['sp.example.com', 'app.example.com'],
+     */
     'trusted.url.domains' => [],
+
+    /*
+     * Enable regular expression matching of trusted.url.domains.
+     *
+     * Set to true to treat the values in trusted.url.domains as regular
+     * expressions. Set to false to do exact string matching.
+     *
+     * If enabled, the start and end delimiters ('^' and '$') will be added to
+     * all regular expressions in trusted.url.domains.
+     */
     'trusted.url.regex' => false,
+
+    /*
+     * Enable secure POST from HTTPS to HTTP.
+     *
+     * If you have some SP's on HTTP and IdP is normally on HTTPS, this option
+     * enables secure POSTing to HTTP endpoint without warning from browser.
+     *
+     * For this to work, module.php/core/postredirect.php must be accessible
+     * also via HTTP on IdP, e.g. if your IdP is on
+     * https://idp.example.org/ssp/, then
+     * http://idp.example.org/ssp/module.php/core/postredirect.php must be accessible.
+     */
     'enable.http_post' => false,
+
+    /*
+     * Set the allowed clock skew between encrypting/decrypting assertions
+     *
+     * If you have a server that is constantly out of sync, this option
+     * allows you to adjust the allowed clock-skew.
+     *
+     * Allowed range: 180 - 300
+     * Defaults to 180.
+     */
     'assertion.allowed_clock_skew' => 180,
+
+    /*
+     * Set custom security headers. The defaults can be found in \SimpleSAML\Configuration::DEFAULT_SECURITY_HEADERS
+     *
+     * NOTE: When a header is already set on the response we will NOT overrule it and leave it untouched.
+     *
+     * Whenever you change any of these headers, make sure to validate your config by running your
+     * hostname through a security-test like https://en.internet.nl
+    'headers.security' => [
+        'Content-Security-Policy' => "default-src 'none'; frame-ancestors 'self'; object-src 'none'; script-src 'self'; style-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:; base-uri 'none'",
+        'Referrer-Policy' => 'origin-when-cross-origin',
+        'X-Content-Type-Options' => 'nosniff',
+    ],
+     */
+
+
+    /************************
+     | ERRORS AND DEBUGGING |
+     ************************/
+
+    /*
+     * The 'debug' option allows you to control how SimpleSAMLphp behaves in certain
+     * situations where further action may be taken
+     *
+     * It can be left unset, in which case, debugging is switched off for all actions.
+     * If set, it MUST be an array containing the actions that you want to enable, or
+     * alternatively a hashed array where the keys are the actions and their
+     * corresponding values are booleans enabling or disabling each particular action.
+     *
+     * SimpleSAMLphp provides some pre-defined actions, though modules could add new
+     * actions here. Refer to the documentation of every module to learn if they
+     * allow you to set any more debugging actions.
+     *
+     * The pre-defined actions are:
+     *
+     * - 'saml': this action controls the logging of SAML messages exchanged with other
+     * entities. When enabled ('saml' is present in this option, or set to true), all
+     * SAML messages will be logged, including plaintext versions of encrypted
+     * messages.
+     *
+     * - 'backtraces': this action controls the logging of error backtraces so you
+     * can debug any possible errors happening in SimpleSAMLphp.
+     *
+     * - 'validatexml': this action allows you to validate SAML documents against all
+     * the relevant XML schemas. SAML 1.1 messages or SAML metadata parsed with
+     * the XML to SimpleSAMLphp metadata converter or the metaedit module will
+     * validate the SAML documents if this option is enabled.
+     *
+     * If you want to disable debugging completely, unset this option or set it to an
+     * empty array.
+     */
     'debug' => [
-        'saml' => false,
-        'backtraces' => false,
+        //'saml' => false,
+        'saml' => true,
+        'backtraces' => true,
         'validatexml' => false,
     ],
+
+    /*
+     * When 'showerrors' is enabled, all error messages and stack traces will be output
+     * to the browser.
+     *
+     * When 'errorreporting' is enabled, a form will be presented for the user to report
+     * the error to 'technicalcontact_email'.
+     */
     'showerrors' => true,
+    //'errorreporting' => true,
     'errorreporting' => false,
+
+    /*
+     * Custom error show function called from SimpleSAML\Error\Error::show.
+     * See docs/simplesamlphp-errorhandling.md for function code example.
+     *
+     * Example:
+     *   'errors.show_function' => ['SimpleSAML\Module\example\Error', 'show'],
+     */
+
+
+    /**************************
+     | LOGGING AND STATISTICS |
+     **************************/
+
+    /*
+     * Define the minimum log level to log. Available levels:
+     * - SimpleSAML\Logger::ERR     No statistics, only errors
+     * - SimpleSAML\Logger::WARNING No statistics, only warnings/errors
+     * - SimpleSAML\Logger::NOTICE  Statistics and errors
+     * - SimpleSAML\Logger::INFO    Verbose logs
+     * - SimpleSAML\Logger::DEBUG   Full debug logs - not recommended for production
+     *
+     * Choose logging handler.
+     *
+     * Options: [syslog,file,errorlog,stderr]
+     *
+     * If you set the handler to 'file', the directory specified in loggingdir above
+     * must exist and be writable for SimpleSAMLphp. If set to something else, set
+     * loggingdir above to 'null'.
+     */
     'logging.level' => SimpleSAML\Logger::NOTICE,
+    //'logging.handler' => 'syslog',
     'logging.handler' => 'stderr',
-    'logging.handler' => 'file',
+
+    /*
+     * Specify the format of the logs. Its use varies depending on the log handler used (for instance, you cannot
+     * control here how dates are displayed when using the syslog or errorlog handlers), but in general the options
+     * are:
+     *
+     * - %date{<format>}: the date and time, with its format specified inside the brackets. See the PHP documentation
+     *   of the date() function for more information on the format. If the brackets are omitted, the standard
+     *   format is applied. This can be useful if you just want to control the placement of the date, but don't care
+     *   about the format.
+     *
+     * - %process: the name of the SimpleSAMLphp process. Remember you can configure this in the 'logging.processname'
+     *   option below.
+     *
+     * - %level: the log level (name or number depending on the handler used).
+     *
+     * - %stat: if the log entry is intended for statistical purposes, it will print the string 'STAT ' (bear in mind
+     *   the trailing space).
+     *
+     * - %trackid: the track ID, an identifier that allows you to track a single session.
+     *
+     * - %srcip: the IP address of the client. If you are behind a proxy, make sure to modify the
+     *   $_SERVER['REMOTE_ADDR'] variable on your code accordingly to the X-Forwarded-For header.
+     *
+     * - %msg: the message to be logged.
+     *
+     */
+    //'logging.format' => '%date{M j H:i:s} %process %level %stat[%trackid] %msg',
+
+    /*
+     * Choose which facility should be used when logging with syslog.
+     *
+     * These can be used for filtering the syslog output from SimpleSAMLphp into its
+     * own file by configuring the syslog daemon.
+     *
+     * See the documentation for openlog (http://php.net/manual/en/function.openlog.php) for available
+     * facilities. Note that only LOG_USER is valid on windows.
+     *
+     * The default is to use LOG_LOCAL5 if available, and fall back to LOG_USER if not.
+     */
     'logging.facility' => defined('LOG_LOCAL5') ? constant('LOG_LOCAL5') : LOG_USER,
+
+    /*
+     * The process name that should be used when logging to syslog.
+     * The value is also written out by the other logging handlers.
+     */
     'logging.processname' => 'simplesamlphp',
+
+    /*
+     * Logging: file - Logfilename in the loggingdir from above.
+     */
     'logging.logfile' => 'simplesamlphp.log',
-    'statistics.out' => [// Log statistics to the normal log.
+
+    /*
+     * This is an array of outputs. Each output has at least a 'class' option, which
+     * selects the output.
+     */
+    'statistics.out' => [
+        // Log statistics to the normal log.
+        /*
+        [
+            'class' => 'core:Log',
+            'level' => 'notice',
+        ],
+        */
+        // Log statistics to files in a directory. One file per day.
+        /*
+        [
+            'class' => 'core:File',
+            'directory' => '/var/log/stats',
+        ],
+        */
     ],
+
+
+
+    /***********************
+     | PROXY CONFIGURATION |
+     ***********************/
+
+    /*
+     * Proxy to use for retrieving URLs.
+     *
+     * Example:
+     *   'proxy' => 'tcp://proxy.example.com:5100'
+     */
     'proxy' => null,
+
+    /*
+     * Username/password authentication to proxy (Proxy-Authorization: Basic)
+     * Example:
+     *   'proxy.auth' = 'myuser:password'
+     */
+    //'proxy.auth' => 'myuser:password',
+
+
+
+    /**************************
+     | DATABASE CONFIGURATION |
+     **************************/
+
+    /*
+     * This database configuration is optional. If you are not using
+     * core functionality or modules that require a database, you can
+     * skip this configuration.
+     */
+
+    /*
+     * Database connection string.
+     * Ensure that you have the required PDO database driver installed
+     * for your connection string.
+     */
+    'database.dsn' => 'mysql:host=localhost;dbname=saml',
+
+    /*
+     * SQL database credentials
+     */
+    'database.username' => 'simplesamlphp',
+    'database.password' => 'secret',
+    'database.options' => [],
+
+    /*
+     * (Optional) Table prefix
+     */
+    'database.prefix' => '',
+
+    /*
+     * (Optional) Driver options
+     */
+    'database.driver_options' => [],
+
+    /*
+     * True or false if you would like a persistent database connection
+     */
+    'database.persistent' => false,
+
+    /*
+     * Database secondary configuration is optional as well. If you are only
+     * running a single database server, leave this blank. If you have
+     * a primary/secondary configuration, you can define as many secondary servers
+     * as you want here. Secondaries will be picked at random to be queried from.
+     *
+     * Configuration options in the secondary array are exactly the same as the
+     * options for the primary (shown above) with the exception of the table
+     * prefix and driver options.
+     */
+    'database.secondaries' => [
+        /*
+        [
+            'dsn' => 'mysql:host=mysecondary;dbname=saml',
+            'username' => 'simplesamlphp',
+            'password' => 'secret',
+            'persistent' => false,
+        ],
+        */
+    ],
+
+
+
+    /*************
+     | PROTOCOLS |
+     *************/
+
+    /*
+     * Which functionality in SimpleSAMLphp do you want to enable. Normally you would enable only
+     * one of the functionalities below, but in some cases you could run multiple functionalities.
+     * In example when you are setting up a federation bridge.
+     */
+    //'enable.saml20-idp' => false,
     'enable.saml20-idp' => true,
-    'enable.adfs-idp' => false,
-    'module.enable' => [
-        'exampleauth' => true,
+    //'enable.adfs-idp' => false,
+    'enable.adfs-idp' => true,
+
+
+
+    /***********
+     | MODULES |
+     ***********/
+
+    /*
+     * Configuration for enabling/disabling modules. By default the 'core', 'admin' and 'saml' modules are enabled.
+     *
+     * Example:
+     *
+     * 'module.enable' => [
+     *     'exampleauth' => true, // Setting to TRUE enables.
+     *     'consent' => false, // Setting to FALSE disables.
+     *     'core' => null, // Unset or NULL uses default.
+     * ],
+     */
+
+    'module.enable' => [        
         'core' => true,
         'admin' => true,
         'saml' => true,
-        'DebugSP' => true,
+
+        'exampleauth' => true,            
+        'debugsp' => true,
         'saml2debug' => true,
     ],
+
+
+
+    /*************************
+     | SESSION CONFIGURATION |
+     *************************/
+
+    /*
+     * This value is the duration of the session in seconds. Make sure that the time duration of
+     * cookies both at the SP and the IdP exceeds this duration.
+     */
     'session.duration' => 8 * (60 * 60), // 8 hours.
+
+    /*
+     * Sets the duration, in seconds, data should be stored in the datastore. As the data store is used for
+     * login and logout requests, this option will control the maximum time these operations can take.
+     * The default is 4 hours (4*60*60) seconds, which should be more than enough for these operations.
+     */
     'session.datastore.timeout' => (4 * 60 * 60), // 4 hours
+
+    /*
+     * Sets the duration, in seconds, auth state should be stored.
+     */
     'session.state.timeout' => (60 * 60), // 1 hour
+
+    /*
+     * Option to override the default settings for the session cookie name
+     */
     'session.cookie.name' => 'SimpleSAMLSessionID',
+
+    /*
+     * Expiration time for the session cookie, in seconds.
+     *
+     * Defaults to 0, which means that the cookie expires when the browser is closed.
+     *
+     * Example:
+     *  'session.cookie.lifetime' => 30*60,
+     */
     'session.cookie.lifetime' => 0,
+
+    /*
+     * Limit the path of the cookies.
+     *
+     * Can be used to limit the path of the cookies to a specific subdirectory.
+     *
+     * Example:
+     *  'session.cookie.path' => '/simplesaml/',
+     */
     'session.cookie.path' => '/',
+
+    /*
+     * Cookie domain.
+     *
+     * Can be used to make the session cookie available to several domains.
+     *
+     * Example:
+     *  'session.cookie.domain' => '.example.org',
+     */
     'session.cookie.domain' => '',
+
+    /*
+     * Set the secure flag in the cookie.
+     *
+     * Set this to TRUE if the user only accesses your service
+     * through https. If the user can access the service through
+     * both http and https, this must be set to FALSE.
+     */
     'session.cookie.secure' => true,
+
+    /*
+     * Set the SameSite attribute in the cookie.
+     *
+     * You can set this to the strings 'None', 'Lax', or 'Strict' to support
+     * the RFC6265bis SameSite cookie attribute. If set to null, no SameSite
+     * attribute will be sent.
+     *
+     * A value of "None" is required to properly support cross-domain POST
+     * requests which are used by different SAML bindings. Because some older
+     * browsers do not support this value, the canSetSameSiteNone function
+     * can be called to only set it for compatible browsers.
+     *
+     * You must also set the 'session.cookie.secure' value above to true.
+     *
+     * Example:
+     *  'session.cookie.samesite' => 'None',
+     */
     'session.cookie.samesite' => $httpUtils->canSetSameSiteNone() ? 'None' : null,
+
+    /*
+     * Options to override the default settings for php sessions.
+     */
     'session.phpsession.cookiename' => 'SimpleSAML',
     'session.phpsession.savepath' => null,
     'session.phpsession.httponly' => true,
+
+    /*
+     * Option to override the default settings for the auth token cookie
+     */
     'session.authtoken.cookiename' => 'SimpleSAMLAuthToken',
+
+    /*
+     * Options for remember me feature for IdP sessions. Remember me feature
+     * has to be also implemented in authentication source used.
+     *
+     * Option 'session.cookie.lifetime' should be set to zero (0), i.e. cookie
+     * expires on browser session if remember me is not checked.
+     *
+     * Session duration ('session.duration' option) should be set according to
+     * 'session.rememberme.lifetime' option.
+     *
+     * It's advised to use remember me feature with session checking function
+     * defined with 'session.check_function' option.
+     */
     'session.rememberme.enable' => false,
     'session.rememberme.checked' => false,
     'session.rememberme.lifetime' => (14 * 86400),
+
+    /*
+     * Custom function for session checking called on session init and loading.
+     * See docs/simplesamlphp-advancedfeatures.md for function code example.
+     *
+     * Example:
+     *   'session.check_function' => ['\SimpleSAML\Module\example\Util', 'checkSession'],
+     */
+
+
+
+    /**************************
+     | MEMCACHE CONFIGURATION |
+     **************************/
+
+    /*
+     * Configuration for the 'memcache' session store. This allows you to store
+     * multiple redundant copies of sessions on different memcache servers.
+     *
+     * 'memcache_store.servers' is an array of server groups. Every data
+     * item will be mirrored in every server group.
+     *
+     * Each server group is an array of servers. The data items will be
+     * load-balanced between all servers in each server group.
+     *
+     * Each server is an array of parameters for the server. The following
+     * options are available:
+     *  - 'hostname': This is the hostname or ip address where the
+     *    memcache server runs. This is the only required option.
+     *  - 'port': This is the port number of the memcache server. If this
+     *    option isn't set, then we will use the 'memcache.default_port'
+     *    ini setting. This is 11211 by default.
+     *
+     * When using the "memcache" extension, the following options are also
+     * supported:
+     *  - 'weight': This sets the weight of this server in this server
+     *    group. http://php.net/manual/en/function.Memcache-addServer.php
+     *    contains more information about the weight option.
+     *  - 'timeout': The timeout for this server. By default, the timeout
+     *    is 3 seconds.
+     *
+     * Example of redundant configuration with load balancing:
+     * This configuration makes it possible to lose both servers in the
+     * a-group or both servers in the b-group without losing any sessions.
+     * Note that sessions will be lost if one server is lost from both the
+     * a-group and the b-group.
+     *
+     * 'memcache_store.servers' => [
+     *     [
+     *         ['hostname' => 'mc_a1'],
+     *         ['hostname' => 'mc_a2'],
+     *     ],
+     *     [
+     *         ['hostname' => 'mc_b1'],
+     *         ['hostname' => 'mc_b2'],
+     *     ],
+     * ],
+     *
+     * Example of simple configuration with only one memcache server,
+     * running on the same computer as the web server:
+     * Note that all sessions will be lost if the memcache server crashes.
+     *
+     * 'memcache_store.servers' => [
+     *     [
+     *         ['hostname' => 'localhost'],
+     *     ],
+     * ],
+     *
+     * Additionally, when using the "memcached" extension, unique keys must
+     * be provided for each group of servers if persistent connections are
+     * desired. Each server group can also have an "options" indexed array
+     * with the options desired for the given group:
+     *
+     * 'memcache_store.servers' => [
+     *     'memcache_group_1' => [
+     *         'options' => [
+     *              \Memcached::OPT_BINARY_PROTOCOL => true,
+     *              \Memcached::OPT_NO_BLOCK => true,
+     *              \Memcached::OPT_TCP_NODELAY => true,
+     *              \Memcached::OPT_LIBKETAMA_COMPATIBLE => true,
+     *         ],
+     *         ['hostname' => '127.0.0.1', 'port' => 11211],
+     *         ['hostname' => '127.0.0.2', 'port' => 11211],
+     *     ],
+     *
+     *     'memcache_group_2' => [
+     *         'options' => [
+     *              \Memcached::OPT_BINARY_PROTOCOL => true,
+     *              \Memcached::OPT_NO_BLOCK => true,
+     *              \Memcached::OPT_TCP_NODELAY => true,
+     *              \Memcached::OPT_LIBKETAMA_COMPATIBLE => true,
+     *         ],
+     *         ['hostname' => '127.0.0.3', 'port' => 11211],
+     *         ['hostname' => '127.0.0.4', 'port' => 11211],
+     *     ],
+     * ],
+     *
+     */
     'memcache_store.servers' => [
         [
             ['hostname' => 'localhost'],
         ],
     ],
+
+    /*
+     * This value allows you to set a prefix for memcache-keys. The default
+     * for this value is 'simpleSAMLphp', which is fine in most cases.
+     *
+     * When running multiple instances of SSP on the same host, and more
+     * than one instance is using memcache, you probably want to assign
+     * a unique value per instance to this setting to avoid data collision.
+     */
     'memcache_store.prefix' => '',
+
+    /*
+     * This value is the duration data should be stored in memcache. Data
+     * will be dropped from the memcache servers when this time expires.
+     * The time will be reset every time the data is written to the
+     * memcache servers.
+     *
+     * This value should always be larger than the 'session.duration'
+     * option. Not doing this may result in the session being deleted from
+     * the memcache servers while it is still in use.
+     *
+     * Set this value to 0 if you don't want data to expire.
+     *
+     * Note: The oldest data will always be deleted if the memcache server
+     * runs out of storage space.
+     */
     'memcache_store.expires' => 36 * (60 * 60), // 36 hours.
+
+
+
+    /*************************************
+     | LANGUAGE AND INTERNATIONALIZATION |
+     *************************************/
+
+    /*
+     * Languages available, RTL languages, and what language is the default.
+     */
     'language.available' => [
         'en', 'no', 'nn', 'se', 'da', 'de', 'sv', 'fi', 'es', 'ca', 'fr', 'it', 'nl', 'lb',
         'cs', 'sk', 'sl', 'lt', 'hr', 'hu', 'pl', 'pt', 'pt-br', 'tr', 'ja', 'zh', 'zh-tw',
@@ -81,8 +836,16 @@ $config = [
     ],
     'language.rtl' => ['ar', 'dv', 'fa', 'ur', 'he'],
     'language.default' => 'en',
+
+    /*
+     * Options to override the default settings for the language parameter
+     */
     'language.parameter.name' => 'language',
     'language.parameter.setcookie' => true,
+
+    /*
+     * Options to override the default settings for the language cookie
+     */
     'language.cookie.name' => 'language',
     'language.cookie.domain' => '',
     'language.cookie.path' => '/',
@@ -90,21 +853,154 @@ $config = [
     'language.cookie.httponly' => false,
     'language.cookie.lifetime' => (60 * 60 * 24 * 900),
     'language.cookie.samesite' => $httpUtils->canSetSameSiteNone() ? 'None' : null,
+
+    /**
+     * Custom getLanguage function called from SimpleSAML\Locale\Language::getLanguage().
+     * Function should return language code of one of the available languages or NULL.
+     * See SimpleSAML\Locale\Language::getLanguage() source code for more info.
+     *
+     * This option can be used to implement a custom function for determining
+     * the default language for the user.
+     *
+     * Example:
+     *   'language.get_language_function' => ['\SimpleSAML\Module\example\Template', 'getLanguage'],
+     */
+
+    /**************
+     | APPEARANCE |
+     **************/
+
+    /*
+     * Which theme directory should be used?
+     */
     'theme.use' => 'default',
+
+    /*
+     * Set this option to the text you would like to appear at the header of each page. Set to false if you don't want
+     * any text to appear in the header.
+     */
+    //'theme.header' => 'SimpleSAMLphp',
+
+    /**
+     * A template controller, if any.
+     *
+     * Used to intercept certain parts of the template handling, while keeping away unwanted/unexpected hooks. Set
+     * the 'theme.controller' configuration option to a class that implements the
+     * \SimpleSAML\XHTML\TemplateControllerInterface interface to use it.
+     */
+    //'theme.controller' => '',
+
+    /*
+     * Templating options
+     *
+     * By default, twig templates are not cached. To turn on template caching:
+     * Set 'template.cache' to an absolute path pointing to a directory that
+     * SimpleSAMLphp has read and write permissions to.
+     */
+    //'template.cache' => '',
+
+    /*
+     * Set the 'template.auto_reload' to true if you would like SimpleSAMLphp to
+     * recompile the templates (when using the template cache) if the templates
+     * change. If you don't want to check the source templates for every request,
+     * set it to false.
+     */
     'template.auto_reload' => false,
+
+    /*
+     * Set this option to true to indicate that your installation of SimpleSAMLphp
+     * is running in a production environment. This will affect the way resources
+     * are used, offering an optimized version when running in production, and an
+     * easy-to-debug one when not. Set it to false when you are testing or
+     * developing the software, in which case a banner will be displayed to remind
+     * users that they're dealing with a non-production instance.
+     *
+     * Defaults to true.
+     */
     'production' => true,
+
+    /*
+     * SimpleSAMLphp modules can host static resources which are served through PHP.
+     * The serving of the resources can be configured through these settings.
+     */
     'assets' => [
+        /*
+         * These settings adjust the caching headers that are sent
+         * when serving static resources.
+         */
         'caching' => [
+            /*
+             * Amount of seconds before the resource should be fetched again
+             */
             'max_age' => 86400,
+            /*
+             * Calculate a checksum of every file and send it to the browser
+             * This allows the browser to avoid downloading assets again in situations
+             * where the Last-Modified header cannot be trusted,
+             * for example in cluster setups
+             *
+             * Defaults false
+             */
             'etag' => false,
         ],
     ],
+
+    /**
+     * Set to a full URL if you want to redirect users that land on SimpleSAMLphp's
+     * front page to somewhere more useful. If left unset, a basic welcome message
+     * is shown.
+     */
+    //'frontpage.redirect' => 'https://example.com/',
+
+    /*********************
+     | DISCOVERY SERVICE |
+     *********************/
+
+    /*
+     * Whether the discovery service should allow the user to save his choice of IdP.
+     */
     'idpdisco.enableremember' => true,
     'idpdisco.rememberchecked' => true,
+
+    /*
+     * The disco service only accepts entities it knows.
+     */
     'idpdisco.validate' => true,
+
     'idpdisco.extDiscoveryStorage' => null,
+
+    /*
+     * IdP Discovery service look configuration.
+     * Whether to display a list of idp or to display a dropdown box. For many IdP' a dropdown box
+     * gives the best use experience.
+     *
+     * When using dropdown box a cookie is used to highlight the previously chosen IdP in the dropdown.
+     * This makes it easier for the user to choose the IdP
+     *
+     * Options: [links,dropdown]
+     */
     'idpdisco.layout' => 'dropdown',
+
+
+
+    /*************************************
+     | AUTHENTICATION PROCESSING FILTERS |
+     *************************************/
+
+    /*
+     * Authentication processing filters that will be executed for all IdPs
+     */
     'authproc.idp' => [
+        /* Enable the authproc filter below to add URN prefixes to all attributes
+        10 => [
+            'class' => 'core:AttributeMap', 'addurnprefix'
+        ],
+        */
+        /* Enable the authproc filter below to automatically generated eduPersonTargetedID.
+        20 => 'core:TargetedID',
+        */
+
+        // Adopts language from attribute to use in UI
         30 => 'core:LanguageAdaptor',
 
         45 => [
@@ -112,32 +1008,309 @@ $config = [
             'attributename' => 'realm',
             'type'          => 'saml20-idp-SSO',
         ],
+
+        /* When called without parameters, it will fallback to filter attributes 'the old way'
+         * by checking the 'attributes' parameter in metadata on IdP hosted and SP remote.
+         */
         50 => 'core:AttributeLimit',
+
+        /*
+         * Search attribute "distinguishedName" for pattern and replaces if found
+         */
+        /*
+        60 => [
+            'class' => 'core:AttributeAlter',
+            'pattern' => '/OU=studerende/',
+            'replacement' => 'Student',
+            'subject' => 'distinguishedName',
+            '%replace',
+        ],
+        */
+
+        /*
+         * Consent module is enabled (with no permanent storage, using cookies).
+         */
+        /*
+        90 => [
+            'class' => 'consent:Consent',
+            'store' => 'consent:Cookie',
+            'focus' => 'yes',
+            'checked' => true
+        ],
+        */
+        // If language is set in Consent module it will be added as an attribute.
         99 => 'core:LanguageAdaptor',
     ],
+
+    /*
+     * Authentication processing filters that will be executed for all SPs
+     */
     'authproc.sp' => [
+        /*
+        10 => [
+            'class' => 'core:AttributeMap', 'removeurnprefix'
+        ],
+        */
+
+        /*
+         * Generate the 'group' attribute populated from other variables, including eduPersonAffiliation.
+        60 => [
+            'class' => 'core:GenerateGroups', 'eduPersonAffiliation'
+        ],
+        */
+        /*
+         * All users will be members of 'users' and 'members'
+         */
+        /*
+        61 => [
+            'class' => 'core:AttributeAdd', 'groups' => ['users', 'members']
+        ],
+        */
+
+        // Adopts language from attribute to use in UI
         90 => 'core:LanguageAdaptor',
     ],
+
+
+
+    /**************************
+     | METADATA CONFIGURATION |
+     **************************/
+
+    /*
+     * This option allows you to specify a directory for your metadata outside of the standard metadata directory
+     * included in the standard distribution of the software.
+     */
+    //'metadatadir' => 'metadata',
     'metadatadir' => 'config/metadata',
 
+    /*
+     * This option configures the metadata sources. The metadata sources is given as an array with
+     * different metadata sources. When searching for metadata, SimpleSAMLphp will search through
+     * the array from start to end.
+     *
+     * Each element in the array is an associative array which configures the metadata source.
+     * The type of the metadata source is given by the 'type' element. For each type we have
+     * different configuration options.
+     *
+     * Flat file metadata handler:
+     * - 'type': This is always 'flatfile'.
+     * - 'directory': The directory we will load the metadata files from. The default value for
+     *                this option is the value of the 'metadatadir' configuration option, or
+     *                'metadata/' if that option is unset.
+     *
+     * XML metadata handler:
+     * This metadata handler parses an XML file with either an EntityDescriptor element or an
+     * EntitiesDescriptor element. The XML file may be stored locally, or (for debugging) on a remote
+     * web server.
+     * The XML metadata handler defines the following options:
+     * - 'type': This is always 'xml'.
+     * - 'file': Path to the XML file with the metadata.
+     * - 'url': The URL to fetch metadata from. THIS IS ONLY FOR DEBUGGING - THERE IS NO CACHING OF THE RESPONSE.
+     *
+     * MDQ metadata handler:
+     * This metadata handler looks up for the metadata of an entity at the given MDQ server.
+     * The MDQ metadata handler defines the following options:
+     * - 'type': This is always 'mdq'.
+     * - 'server': Base URL of the MDQ server. Mandatory.
+     * - 'validateCertificate': The certificates file that may be used to sign the metadata. You don't need this
+     *                          option if you don't want to validate the signature on the metadata. Optional.
+     * - 'cachedir': Directory where metadata can be cached. Optional.
+     * - 'cachelength': Maximum time metadata can be cached, in seconds. Defaults to 24
+     *                  hours (86400 seconds). Optional.
+     *
+     * PDO metadata handler:
+     * This metadata handler looks up metadata of an entity stored in a database.
+     *
+     * Note: If you are using the PDO metadata handler, you must configure the database
+     * options in this configuration file.
+     *
+     * The PDO metadata handler defines the following options:
+     * - 'type': This is always 'pdo'.
+     *
+     * Examples:
+     *
+     * This example defines two flatfile sources. One is the default metadata directory, the other
+     * is a metadata directory with auto-generated metadata files.
+     *
+     * 'metadata.sources' => [
+     *     ['type' => 'flatfile'],
+     *     ['type' => 'flatfile', 'directory' => 'metadata-generated'],
+     * ],
+     *
+     * This example defines a flatfile source and an XML source.
+     * 'metadata.sources' => [
+     *     ['type' => 'flatfile'],
+     *     ['type' => 'xml', 'file' => 'idp.example.org-idpMeta.xml'],
+     * ],
+     *
+     * This example defines an mdq source.
+     * 'metadata.sources' => [
+     *      [
+     *          'type' => 'mdq',
+     *          'server' => 'http://mdq.server.com:8080',
+     *          'validateCertificate' => [
+     *              '/var/simplesamlphp/cert/metadata-key.new.crt',
+     *              '/var/simplesamlphp/cert/metadata-key.old.crt'
+     *          ],
+     *          'cachedir' => '/var/simplesamlphp/mdq-cache',
+     *          'cachelength' => 86400
+     *      ]
+     * ],
+     *
+     * This example defines an pdo source.
+     * 'metadata.sources' => [
+     *     ['type' => 'pdo']
+     * ],
+     *
+     * Default:
+     * 'metadata.sources' => [
+     *     ['type' => 'flatfile']
+     * ],
+     */
     'metadata.sources' => [
         ['type' => 'flatfile'],
     ],
+
+    /*
+     * Should signing of generated metadata be enabled by default.
+     *
+     * Metadata signing can also be enabled for a individual SP or IdP by setting the
+     * same option in the metadata for the SP or IdP.
+     */
     'metadata.sign.enable' => false,
+
+    /*
+     * The default key & certificate which should be used to sign generated metadata. These
+     * are files stored in the cert dir.
+     * These values can be overridden by the options with the same names in the SP or
+     * IdP metadata.
+     *
+     * If these aren't specified here or in the metadata for the SP or IdP, then
+     * the 'certificate' and 'privatekey' option in the metadata will be used.
+     * if those aren't set, signing of metadata will fail.
+     */
     'metadata.sign.privatekey' => null,
     'metadata.sign.privatekey_pass' => null,
     'metadata.sign.certificate' => null,
+    'metadata.sign.algorithm' => 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
+
+
+    /****************************
+     | DATA STORE CONFIGURATION |
+     ****************************/
+
+    /*
+     * Configure the data store for SimpleSAMLphp.
+     *
+     * - 'phpsession': Limited datastore, which uses the PHP session.
+     * - 'memcache': Key-value datastore, based on memcache.
+     * - 'sql': SQL datastore, using PDO.
+     * - 'redis': Key-value datastore, based on redis.
+     *
+     * The default datastore is 'phpsession'.
+     */
     'store.type'                    => 'phpsession',
+
+    /*
+     * The DSN the sql datastore should connect to.
+     *
+     * See http://www.php.net/manual/en/pdo.drivers.php for the various
+     * syntaxes.
+     */
     'store.sql.dsn'                 => 'sqlite:/path/to/sqlitedatabase.sq3',
+
+    /*
+     * The username and password to use when connecting to the database.
+     */
     'store.sql.username' => null,
     'store.sql.password' => null,
+
+    /*
+     * The prefix we should use on our tables.
+     */
     'store.sql.prefix' => 'SimpleSAMLphp',
+
+    /*
+     * The driver-options we should pass to the PDO-constructor.
+     */
     'store.sql.options' => [],
+
+    /*
+     * The hostname and port of the Redis datastore instance.
+     */
     'store.redis.host' => 'localhost',
     'store.redis.port' => 6379,
+
+    /*
+     * The credentials to use when connecting to Redis.
+     *
+     * If your Redis server is using the legacy password protection (config
+     * directive "requirepass" in redis.conf) then you should only provide
+     * a password.
+     *
+     * If your Redis server is using ACL's (which are recommended as of
+     * Redis 6+) then you should provide both a username and a password.
+     * See https://redis.io/docs/manual/security/acl/
+     */
     'store.redis.username' => '',
     'store.redis.password' => '',
+
+    /*
+     * Communicate with Redis over a secure connection instead of plain TCP.
+     *
+     * This setting affects both single host connections as
+     * well as Sentinel mode.
+     */
+    'store.redis.tls' => false,
+
+    /*
+     * Verify the Redis server certificate.
+     */
+    'store.redis.insecure' => false,
+
+    /*
+     * Files related to secure communication with Redis.
+     *
+     * Files are searched in the 'certdir' when using relative paths.
+     */
+    'store.redis.ca_certificate' => null,
+    'store.redis.certificate' => null,
+    'store.redis.privatekey' => null,
+
+    /*
+     * The prefix we should use on our Redis datastore.
+     */
     'store.redis.prefix' => 'SimpleSAMLphp',
+
+    /*
+     * The master group to use for Redis Sentinel.
+     */
     'store.redis.mastergroup' => 'mymaster',
+
+    /*
+     * The Redis Sentinel hosts.
+     * Example:
+     * 'store.redis.sentinels' => [
+     *     'tcp://[yoursentinel1]:[port]',
+     *     'tcp://[yoursentinel2]:[port]',
+     *     'tcp://[yoursentinel3]:[port]
+     * ],
+     *
+     * Use 'tls' instead of 'tcp' in order to make use of the additional
+     * TLS settings.
+     */
     'store.redis.sentinels' => [],
+
+    /*********************
+     | IdP/SP PROXY MODE |
+     *********************/
+
+    /*
+     * If the IdP in front of SimpleSAMLphp in IdP/SP proxy mode sends
+     * AuthnContextClassRef, decide whether the AuthnContextClassRef will be
+     * processed by the IdP/SP proxy or if it will be passed to the SP behind
+     * the IdP/SP proxy.
+     */
+    'proxymode.passAuthnContextClassRef' => false,
 ];

--- a/docker/sspconf/metadata/saml20-idp-remote.php
+++ b/docker/sspconf/metadata/saml20-idp-remote.php
@@ -1,13 +1,16 @@
 <?php
 
-// MANAGED BY ANSIBLE
-
 // This file defines remote IdPs. These are the IdPs that the SPs hosted by this SSP instance can use for
-// authentication
-
+// authentication.
 
 ////////////////////////////////////////////////////////////////////////////
 // Idp remote metadata of the IdP hosted at this instance (ssp.dev.openconext.local), for use by the hosted SPs
+// Even though this IdP is hosted by this SSP instance, it is considered remote from the SSP SP's perspective so it needs
+// to be defined here as a remote IdP. This hosted IdP is defined in sspconf/metadata/saml20-idp-hosted.php file.
+
+// $GLOBALS['gSP_SSOBinding'] is set from the Test SP.
+if (! isset($GLOBALS['gSP_SSOBinding']) )
+    $GLOBALS['gSP_SSOBinding'] = 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect';
 
 $metadata['https://ssp.dev.openconext.local/simplesaml/saml2/idp/metadata.php'] = array (
     'entityid' => 'https://ssp.dev.openconext.local/simplesaml/saml2/idp/metadata.php',
@@ -17,29 +20,19 @@ $metadata['https://ssp.dev.openconext.local/simplesaml/saml2/idp/metadata.php'] 
         array (
             0 =>
                 array (
-                    'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
+                    'Binding' => $GLOBALS['gSP_SSOBinding'] ?? 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
                     'Location' => 'https://ssp.dev.openconext.local/simplesaml/saml2/idp/SSOService.php',
-                ),
-        ),
-    'ArtifactResolutionService' =>
-        array (
-            0 =>
-                array (
-                    'index' => 0,
-                    'Location' => 'https://ssp.dev.openconext.local/simplesaml/saml2/idp/ArtifactResolutionService.php',
-                    'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:SOAP',
                 ),
         ),
     'name' => array(
         'en' => 'ssp.dev.openconext.local - SSP Test IdP',
         'nl' => 'ssp.dev.openconext.local - SSP Test IdP',
     ),
-
 );
 
 
 ////////////////////////////////////////////////////////////////////////////
-// The metadata of the OpenConext Stepup IdP, for use by the hosted SPs
+// The metadata of the Stepup-Gateway IdP, for use by the hosted SPs
 
 $metadata['https://gateway.dev.openconext.local/authentication/metadata'] = array (
     'entityid' => 'https://gateway.dev.openconext.local/authentication/metadata',
@@ -52,14 +45,11 @@ $metadata['https://gateway.dev.openconext.local/authentication/metadata'] = arra
         array (
             0 =>
                 array (
-                    'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
+                    'Binding' => $GLOBALS['gSP_SSOBinding'] ?? 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
                     'Location' => 'https://gateway.dev.openconext.local/authentication/single-sign-on',
                 ),
         ),
     'SingleLogoutService' =>
-        array (
-        ),
-    'ArtifactResolutionService' =>
         array (
         ),
     'keys' =>
@@ -76,7 +66,7 @@ $metadata['https://gateway.dev.openconext.local/authentication/metadata'] = arra
 
 
 ////////////////////////////////////////////////////////////////////////////
-// The metadata of the OpenConext Stepup IdP - SFO, for use by the hosted SPs
+// The metadata of the Stepup-Gateway SFO (second factor only) IdP, for use by the hosted SPs
 
 $metadata['https://gateway.dev.openconext.local/second-factor-only/metadata'] = array (
     'entityid' => 'https://gateway.dev.openconext.local/second-factor-only/metadata',
@@ -89,7 +79,7 @@ $metadata['https://gateway.dev.openconext.local/second-factor-only/metadata'] = 
         array (
             0 =>
                 array (
-                    'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
+                    'Binding' => $GLOBALS['gSP_SSOBinding'] ?? 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
                     'Location' => 'https://gateway.dev.openconext.local/second-factor-only/single-sign-on',
                 ),
         ),
@@ -110,23 +100,3 @@ $metadata['https://gateway.dev.openconext.local/second-factor-only/metadata'] = 
                 ),
         ),
 );
-
-
-/**
- * Remove the spicing from the certificate, this is a php port of the python (keyczar) implementation that is used
- * in the ninja templates ( return re.sub(r'\s+|(-----(BEGIN|END).*-----)', '', string) )
- */
-function depem($input)
-{
-    return str_replace([
-        '-----BEGIN CERTIFICATE-----',
-        '-----END CERTIFICATE-----',
-        "\r\n",
-        "\n",
-    ], [
-        '',
-        '',
-        "\n",
-        ''
-    ], $input);
-}

--- a/docker/sspconf/metadata/saml20-sp-remote.php
+++ b/docker/sspconf/metadata/saml20-sp-remote.php
@@ -1,37 +1,52 @@
 <?php
 
-// MANAGED BY ANSIBLE
+// This file contains the remote SAML SPs that the IdP hosted by this SSP instance can authenticate to
 
-// This file contains the remote SPs that the IdP hosted by this instance can authenticate to
+///////////////////////////////////////////////////////////////////////////////////
+// The SPs hosted by this instance
+// Even though the default-sp, second-sp, third-sp and fourth-sp SPs are hosted by this instance, 
+// they are considered remote from the SSP IdP's perspective so they need to be defined here as remote SPs
+// The hosted SPs are defined in sspconf/authsources.php file and are implemented in sspwww/sp.php
+
+foreach (array('default-sp', 'second-sp', 'third-sp', 'fourth-sp') as $sp) {
+    // Alternative metadata URLs:
+    // - SimpleSAMLphp new style: "https://ssp.dev.openconext.local/simplesaml/module.php/saml/sp/metadata/$sp"
+    // - debugsp module: "https://ssp.dev.openconext.local/simplesaml/module.php/debugsp/metadata/$sp"
+
+    // Configure SP entity with entityID. We keep the convention of using the same entityID as the URL of the metadata
+    // and use the old style metadata URL for the entityID because that is what the old version of the devssp used.
+    $entityID = "https://ssp.dev.openconext.local/simplesaml/module.php/saml/sp/metadata.php/$sp";
+    $metadata[$entityID] = array(
+        'name' => array(
+            'en' => "ssp.dev.openconext.local - Local SP ($sp)",
+            'nl' => "ssp.dev.openconext.local - Local SP ($sp)",
+        ),
+        'AssertionConsumerService' =>
+            array (
+                0 =>
+                    array (
+                        'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+                        // Point to debugsp's module ACS
+                        'Location' => "https://ssp.dev.openconext.local/simplesaml/module.php/debugsp/acs/$sp",
+                        'index' => 0,
+                    ),
+            ),
+        'SingleLogoutService' =>
+            array (
+                0 =>
+                    array (
+                        'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
+                        'Location' => "https://ssp.dev.openconext.local/simplesaml/module.php/saml/sp/saml2-logout.php/$sp",
+                    ),
+            ),
+        'certificate' => 'sp.crt'
+    );
+}
 
 
 ///////////////////////////////////////////////////////////////////////////////////
-// The "default-sp" SP hosted by this instance.
-
-$metadata['https://ssp.dev.openconext.local/simplesaml/module.php/saml/sp/metadata.php/default-sp'] = array(
-    'AssertionConsumerService' =>
-        array (
-            0 =>
-                array (
-                    'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
-                    'Location' => 'https://ssp.dev.openconext.local/simplesaml/module.php/saml/sp/saml2-acs.php/default-sp',
-                    'index' => 0,
-                ),
-        ),
-    'SingleLogoutService' =>
-        array (
-            0 =>
-                array (
-                    'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
-                    'Location' => 'https://ssp.dev.openconext.local/simplesaml/module.php/saml/sp/saml2-logout.php/default-sp',
-                ),
-        ),
-    'certificate' => 'sp.crt'
-);
-
-
-///////////////////////////////////////////////////////////////////////////////////
-// Stepup Gateway in it's SP role
+// The Stepup Gateway in it's SP role
+// This allows the SSP IdP in this instance to authenticate to the Stepup Gateway
 
 $metadata['https://gateway.dev.openconext.local/authentication/metadata'] = array(
     'AssertionConsumerService' =>

--- a/docker/sspwww/sp-config.inc
+++ b/docker/sspwww/sp-config.inc
@@ -21,25 +21,28 @@ $gIDPmap = array(
     'https://gateway.dev.openconext.local/authentication/metadata' => array(
         'name' => 'OpenConext Stepup Gateway - gateway.dev.openconext.local',
         'loa' => array(
-            1 => 'http://dev.openconext.local/assurance/loa1',
-            2 => 'http://dev.openconext.local/assurance/loa2',
-            3 => 'http://dev.openconext.local/assurance/loa3',
+            "1" => 'http://dev.openconext.local/assurance/loa1',
+            "1.5" => 'http://dev.openconext.local/assurance/loa1.5',
+            "2" => 'http://dev.openconext.local/assurance/loa2',
+            "3" => 'http://dev.openconext.local/assurance/loa3',
         ),
     ),
     'https://gateway.dev.openconext.local/second-factor-only/metadata' => array(
         'name' => 'OpenConext Stepup Gateway - gateway.dev.openconext.local - SFO',
         'loa' => array(
-            1 => 'https://dev.openconext.local/assurance/sfo-level1', // Note does not exist
-            2 => 'https://dev.openconext.local/assurance/sfo-level2',
-            3 => 'https://dev.openconext.local/assurance/sfo-level3',
+            "1" => 'http://dev.openconext.local/assurance/sfo-level1', // Note does not exist
+            "1.5" => 'http://dev.openconext.local/assurance/sfo-level1', // Note does not exist
+            "2" => 'http://dev.openconext.local/assurance/sfo-level2',
+            "3" => 'http://dev.openconext.local/assurance/sfo-level3',
         ),
     ),
     'https://ssp.dev.openconext.local/simplesaml/saml2/idp/metadata.php' => array(
         'name' => 'Local SSP IdP - ssp.dev.openconext.local',
         'loa' => array(
-            1 => '',
-            2 => '',
-            3 => '',
+            "1" => '',
+            "1.5" => '',
+            "2" => '',
+            "3" => '',
         ),
     ),
 );

--- a/docker/sspwww/sp-config.inc
+++ b/docker/sspwww/sp-config.inc
@@ -3,13 +3,13 @@
 $_SERVER['HTTPS'] = 'on';
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// List of the avaiable remote SAML 2.0 identity providers in the SP interface
+// List of the available remote SAML 2.0 identity providers in the SP interface
 // The SP interface allows selection of the IdP and the (Requested) AuthnContextClassRef
 // The IdP must be configured in saml20-idp-remote.php
 
 $gIDPmap = array(
     /*
-    'EntityID of the IdP as it appers in saml20-idp-remote.php' => array(
+    'EntityID of the IdP as it appears in saml20-idp-remote.php' => array(
         'name' => 'Displayname of the IdP in the SP interface',
         'loa' => array(
           1 => 'AuthnContextClassRef for loa 1',

--- a/docker/sspwww/sp-utils.inc
+++ b/docker/sspwww/sp-utils.inc
@@ -63,9 +63,9 @@ function HTMLColorFingerprint($value)
         }
     }
     // Convert from RGB values (0 .. 1) to hex (00 .. FF)
-    $color='#' .str_pad(dechex($r*256),2,'0',STR_PAD_LEFT)
-        .str_pad(dechex($g*256),2,'0',STR_PAD_LEFT)
-        .str_pad(dechex($b*256),2,'0',STR_PAD_LEFT);
+    $color='#' .str_pad(dechex((int)($r*256)),2,'0',STR_PAD_LEFT)
+        .str_pad(dechex((int)($g*256)),2,'0',STR_PAD_LEFT)
+        .str_pad(dechex((int)($b*256)),2,'0',STR_PAD_LEFT);
     return $color;
 }
 

--- a/docker/sspwww/sp.php
+++ b/docker/sspwww/sp.php
@@ -186,27 +186,46 @@ if (isset($_REQUEST['action']) && $_REQUEST['action'] == 'login' ) {
 
     // Subject NameID
     if ( isset($_REQUEST['subject']) && strlen($_REQUEST['subject']) > 0 ) {
-        $context['saml:NameID'] = array(
-            'Value' => $_REQUEST['subject'],
-            'Format' => SAML2_Const::NAMEID_UNSPECIFIED,
-            'Format' => SAML2_Const::NAMEID_UNSPECIFIED,
-        );
+        $nameId = new \SAML2\XML\saml\NameID();
+        $nameId->setValue($_REQUEST['subject']);  // Use value of "NameID" attribute
+        $nameId->setFormat(\SAML2\Constants::NAMEID_UNSPECIFIED); // Unspecified NameID
+        $context['saml:NameID'] = $nameId;
     }
 
     // AssertionConsumerServiceURL
     if ( isset($_REQUEST['acsurl']) && strlen($_REQUEST['acsurl']) > 0 ) {
-        $context['DebugSP:AssertionConsumerServiceURL'] = $_REQUEST['acsurl'];
+        $context['debugsp:AssertionConsumerServiceURL'] = $_REQUEST['acsurl'];
     }
 
-    // Emulate ADFS
+    // Emulate an authentication request by the SURF MFA extension for ADFS. See: https://github.com/SURFnet/ADFS-MFA-SAML2.0-Extension
+    // The second factor only (SFO) endpoint of the Stepup-Gateway (see: https://github.com/OpenConext/Stepup-Gateway) will give a different
+    // SAML Response when this is enabled. This option allows testing this behaviour without having to install an ADFS server.
+    // The trigger for this behaviour in the stepup-gateway is the presence of the 'Context' and 'AuthMethod' POST variables. This also means that a HTTP-POST
+    // binding must be used.
+    // Additionally the SURF MFA extension for ADFS sets the ACS location in the SAML Request to the URL where the response must be posted.
+    // We add some dummy URL parameters to the ACS location for this purpose.
+    // Because the actual SAML response is posted in the "_SAMLResponse" parameter (instead of "SAMLResponse") the acs location of debugsp module
+    // must be used to validate the response as that will rename the "_SAMLResponse" POST variable back to "SAMLResponse" so that
+    // SimpleSAMLphp can then process it normally.
+    // For more information See: https://github.com/OpenConext/Stepup-Gateway/blob/main/docs/SFO.md#adfs-mfa-extension
     if ( (isset($_REQUEST['emulateadfs'])) && ($_REQUEST['emulateadfs'] == 'true') )
     {
-        $context['DebugSP:extraPOSTvars'] = array(
+        // Switch binding to HTTP-POST
+        $ssobinding = $GLOBALS['gSP_SSOBinding'] = 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST';
+
+        // Set AuthMethod and mock Context like the SURF MFA extension for ADFS would do
+        $context['debugsp:extraPOSTvars'] = array(
             'AuthMethod' => 'ADFS.SCSA',
             'Context' => '<EncryptedData Type="http://www.w3.org/2001/04/xmlenc#Content" xmlns="http://www.w3.org/2001/04/xmlenc#"><EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes256-cbc" /><KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#"><EncryptedKey xmlns="http://www.w3.org/2001/04/xmlenc#"><EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5" /><KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#"><KeyName>1C63828278F1B0AC2FE61429E099FFA7AC94917C</KeyName></KeyInfo><CipherData><CipherValue>Qe1t1xgG78zLHhUxBXm0ous4yl0zfQumsKI79lrHMOIjdTdeF/i1Yx+pQ+mgnubT9mh+DfBYMs7wU1g+eXiAs2gnwKWmnMzeuxgG+m5Nky5Wd63NcEgLZ2zNTYuW70X514HMtLAw+l1H8cptQMXfXt9ageHOdY+65eq4IsNwnB0mPhRkua58R9xO3I4MfBzy90GqwgjmDeZAo5vsKgk0iZRgZ1CS4hPyIWX+ryU2tnYp5UEuDE9gGlR9cQr2uHW10LOG22ZfEy8rJie2T2A2bCQVyF47nmBnvoKYV6YyEDpozSYJpUqHmIgvaWgFu5dvDvZ0fvrVQaQ1ZUKHTT76Cg==</CipherValue></CipherData></EncryptedKey></KeyInfo><CipherData><CipherValue>6SO/qvyH0bmayeNGyzqAy/Oim2UAOvhxm18rTs+72Qm2fSK6Pfo1ZEDNKmLRk6IemCvkUYWMa4VmxIdATswREx/aSrp4YS3QejDBoZlCwz4LqFWJMiqTPxJfWhahP0hBNEORN8cU5vBQXXIahWqlkaHzs6IPjH4WoMe5vsSKVTetaOMbMC3ZML67BWpAnEXKWoR/gar1jH5v961ljdKJozzgwsJIAY4TNSoB+AEzRd4C3wLSTCott1DyRtMmEmS5DpaDOaxmZ/X+z16t1hb9VKgEqt1xZJ0uw451d5oeuisN9zSqbWQzyiJdkk6k11YU9q2rvg342qLJk6xeTtRc6+DLQ24vZIHC8RU2jcHveLDJvOq89BBJ0LHtnV/7PJpb4PGf1OUqWZidnRAS0/dqprEVzPEnvdzIJ8vPRGzE0dkQhgzDi+cbMsuZrDqYWaMuodvDbGrETxZ9hu0MI3l9pgjuIh8xF7TT/6qTJnGExRaGFebcjMXC99thZ3A7XeJESDNXNxgDgFQf6OwHLjLuhw==</CipherValue></CipherData><Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" /><SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1" /><Reference URI=""><Transforms><Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" /></Transforms><DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" /><DigestValue>va+cZ6Y7NIyBU9vCVb+qRGSx0Yk=</DigestValue></Reference></SignedInfo><SignatureValue>DNF3KVEb8ju/T+ise1j0QBS2OYsepwzgWaUtOASvUPI6NPlvyQIHxX1Py6oHcUkbWP1jaVTzwEGadaq428nPMWSeU/MDWqyz2jyrwuIUWglc64AMlcXd0BOdT1I6khKMsUGY8CSa1tRD2arcIH1TUrrk7jY3qfAGtgNbFlElPwc/2l4dkN7QXdHRcmntFp4D/9yEG9FkWzTyXLvCvGqcQeu8L1fKTwq8Upqk9iT2PKnmT/gH+IUt3votmCMV9bxYols0aQWfv2RX2HX3Gow9xKZuOn+ckjZRqBJ1Kp9wGMAB65XQPli5UQzezEHX28oUPH/PEgnu6RKDgsN55h22ag==</SignatureValue><KeyInfo><KeyName>DB540D051F8F73EA2F3B5190BFC0F349E595EB34</KeyName></KeyInfo></Signature></EncryptedData> SAMLRequest: PHNhbWwycDpBdXRoblJlcXVlc3QgeG1sbnM6c2FtbDJwPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6cHJvdG9jb2wiIHhtbG5zOnNhbWwyPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6YXNzZXJ0aW9uIiBJRD0iXzkwZWFkMWNlLTM3NmMtNGE1ZC05ODAzLWQ5Y2M4MDA2M2Q0ZiIgVmVyc2lvbj0iMi4wIiBJc3N1ZUluc3RhbnQ9IjIwMTgtMDQtMjNUMTM6NDk6NTBaIiBEZXN0aW5hdGlvbj0iaHR0cHM6Ly9zYS1ndy50ZXN0Mi5zdXJmY29uZXh0Lm5sL3NlY29uZC1mYWN0b3Itb25seS9zaW5nbGUtc2lnbi1vbiIgQXNzZXJ0aW9uQ29uc3VtZXJTZXJ2aWNlVVJMPSJodHRwczovL2FkZnMtMjAxMi50ZXN0Mi5zdXJmY29uZXh0Lm5sOjQ0My9hZGZzL2xzLz9TQU1MUmVxdWVzdD1wVkpOanhNeERQMHJvOXpubzVscFlhTzJVdGtLVVdtQmFsczRjRUZ1eGtNalpaSWhkbUQ1OTZRcGlJVkRMNXdTUGZzOVB6OTVTVERhU1cwaW45MGpmbzFJWER5TjFwSEtoWldJd1NrUFpFZzVHSkVVYTNYWXZIMVFzbXJVRkR4NzdhMTRScm5OQUNJTWJMd1R4VzY3RXAlMkZiMmVtdTBYTG90SnpMUmklMkJHV1R1SHJwJTJGTCUyQlFKMXYyaFBKOTNjZFMwTUlJcVBHQ2d4VnlJSkpUcFJ4SjBqQnNjSmFtWXZ5NllyWlh1Y3RhcGJxUGJGSjFGczB6YkdBV2ZXbVhraVZkZlFEMVNtZmxseEtzdUtZaGkwZCUyRmpFbGJPNVdsdXFSYkg1YmZYZU80b2poZ09HYjBiamg4ZUhQMktUUWNaUUFaaXM0ekNMa0Jrbml6bkE4MVNQdm84V3E4djNBdFYwZldVSm1qTGE0d0RSY2ttVEtQYSUyRkluMWxYRyUyRmNsOXRwbnE1TnBONGNqJTJGdHklMkYlMkY1d0ZPdmxSVnZsZE1MNlAyMk95TkFEd3o4dWwlMkZYekdjdnJCYjFMN25iYnZiZEclMkZ5aGUlMkJ6QUMzelolMkZRVXhmRHJsVmNRQkhCaDJuNEszMTMlMkI4REF1TktjSWdvNnZWMTVOOTN1djRKJmFtcDtSZWxheVN0YXRlPWh0dHBzJTNBJTJGJTJGcGlldGVyLmFhaS5zdXJmbmV0Lm5sJTJGc2ltcGxlc2FtbHBocCUyRnNwLnBocCUzRnNwJTNEZGVmYXVsdC1zcCZhbXA7U2lnQWxnPWh0dHAlM0ElMkYlMkZ3d3cudzMub3JnJTJGMjAwMSUyRjA0JTJGeG1sZHNpZy1tb3JlJTIzcnNhLXNoYTI1NiZhbXA7U2lnbmF0dXJlPUt6TzhYV0liVTZGdUVWZVZ4RFlNZzJ1T2xoZTlBQVAwd09uWlZVM3RVMU1ibWNKUDlXa3Q1Z0R3a2RKcXhDbUlJWGVDdnBhNDVLWUdlTzNFNWppampSOHlMUFpTalJUalJRem81V2h5bzJTaXRjTkxOZzZ4WFdZY0Z6bmdIcEdKeGRyJTJGVmxjSTR0RXFUNFZSN0VwbXp3amJtd1RaRGMyOW9hdEtZRGNUUjBjTjh2M0VtMVRIR0ZOc1B0bERvRVd5c0laWjFONkRpRVAxYmE4aTE5OVhoRiUyQldXZzVzNHdqMXltMnBDendQelJkYyUyRmpreDRQcG1MTyUyQjNVY3R3amoySG5RNmNiJTJCeHBsJTJCJTJCVUFwalZ1a3ZlNWdiempMbzI4JTJCUGklMkZXQmJ0Ym0lMkZrMzE5UlZ2dWFEdVVvJTJGM3VTUU1BJTJCbHR6b0ZIOGEwRTJ0Q0pNVGg1TWRnUm10ZyUzRCUzRCI+DQogIDxzYW1sMjpJc3N1ZXI+aHR0cDovL2FkZnMtMjAxMi50ZXN0Mi5zdXJmY29uZXh0Lm5sPC9zYW1sMjpJc3N1ZXI+PFNpZ25hdHVyZSB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC8wOS94bWxkc2lnIyI+PFNpZ25lZEluZm8+PENhbm9uaWNhbGl6YXRpb25NZXRob2QgQWxnb3JpdGhtPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxLzEwL3htbC1leGMtYzE0biMiIC8+PFNpZ25hdHVyZU1ldGhvZCBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvMDQveG1sZHNpZy1tb3JlI3JzYS1zaGEyNTYiIC8+PFJlZmVyZW5jZSBVUkk9IiNfOTBlYWQxY2UtMzc2Yy00YTVkLTk4MDMtZDljYzgwMDYzZDRmIj48VHJhbnNmb3Jtcz48VHJhbnNmb3JtIEFsZ29yaXRobT0iaHR0cDovL3d3dy53My5vcmcvMjAwMC8wOS94bWxkc2lnI2VudmVsb3BlZC1zaWduYXR1cmUiIC8+PFRyYW5zZm9ybSBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvMTAveG1sLWV4Yy1jMTRuIyIgLz48L1RyYW5zZm9ybXM+PERpZ2VzdE1ldGhvZCBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvMDQveG1sZW5jI3NoYTI1NiIgLz48RGlnZXN0VmFsdWU+Q2ZKV1hpTXJLU0g0b3pPVWZTL0VNOXBXbFRSc3p2QkpMN2Y3MUZrZ3ZCbz08L0RpZ2VzdFZhbHVlPjwvUmVmZXJlbmNlPjwvU2lnbmVkSW5mbz48U2lnbmF0dXJlVmFsdWU+YzFqakFhdnVjMi9TSHZQYzdJdktJVkRSZUZuZVAzbTlITkZzTzErZEx2bWhxUXl5NkhoN3ZRMlFJalVGb2FybkYxZnJpOUY1RlNxL2JsR1I4RENvNEpndUlxKzNnRXBjN1JYR2EyTWc4dE5CV2tWdUg2UnZBTGM1Qk5DSDNtODVTTHgwcklGbERWc0tzZi9IQ0lTc2taV3Z6VVJGVVRFZnZjRVljWjZZZjNXYURmK1YvbE5jYXpCeVQ0L3RmNVVFN0VIM1JYckc2dUFqbHhjekN4a09UUE1SMnIvNmxwaEF1UmIxcjY1bThYQXFZNVFnbG5SVXBOM3U3ZEt4bGN5VUVaY2xKTW5JN21ya2NyMUdwODV6allkK0N4TmFwanNEQXplVjdSSVNLdHNaY0NFYWhncStIdTZVOEtBUmZHZmdFQ1dZNGY0c2lWRGp2d0NVaTlUME13PT08L1NpZ25hdHVyZVZhbHVlPjxLZXlJbmZvPjxYNTA5RGF0YT48WDUwOUNlcnRpZmljYXRlPk1JSURFekNDQWZ1Z0F3SUJBZ0lRU044elc2Q1lsSUpPQUZ6ZFN0VFQrakFOQmdrcWhraUc5dzBCQVFzRkFEQXNNU293S0FZRFZRUUREQ0Z6YVdkdWFXNW5MbVF5TURFeUxuUmxjM1F5TG5OMWNtWmpiMjVsZUhRdWJtd3dIaGNOTVRjd09USTBNVFl6TkRFM1doY05Nakl3T1RJMU1UWXpOREUzV2pBc01Tb3dLQVlEVlFRRERDRnphV2R1YVc1bkxtUXlNREV5TG5SbGMzUXlMbk4xY21aamIyNWxlSFF1Ym13d2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUUNkL1RXMUpvY05PV2w1aUZsN1JrWTQwa1A1U2NpQllCNnRJRXl3ZmxGNHRrRUR3S1Jxc1EyRXNaOTN1aWdnQi9wWFVhNlRHdlM3dnpRalJxZGhGZ0Nwb2htaGVwUzlQd3UvL0krcDY4VlpDdHNsdDFVSkd0NjJBRk9ad2FUU1FQbjRlR2RoRHI0c1g5TXIrdVVPU1plZWlEdHVFaGlNSWprZDJJYWJPeVNkOUxTK05Nc29pY1NoWEd5MERZR05yN2gyaHl1L2xUK3VMSnZsUFJ0V29aNDdpS1kwVUdpcVNJN013WlNQQjBoT2p5ZW9wbCsvWExENGhEKzNWVUFDMkttSDZaTzBBYWErc1JRZStNVFlVNHZvN29YTitkaEZoOG9VcFFrNjN4MjBtYTE1N3RSU1lqQlVwTURkclMvdk4vNWQ3c21URnQ1dFV4dlVHTGNGR0E4SkFnTUJBQUdqTVRBdk1BNEdBMVVkRHdFQi93UUVBd0lIZ0RBZEJnTlZIUTRFRmdRVUZ2ZzR3d3ByTDBlWi9ZL09zSDkyVDMrK3RsVXdEUVlKS29aSWh2Y05BUUVMQlFBRGdnRUJBRXEvQ2p5N2J0THFmWnp4dlZwUEJYZnVmYk5RSHJBeFY1QnA2a0QyY0NYUzlWQ0swdUdKdkZsemRVMDNDTE9uME4xYTJBUU5JSmZPZVg2dXlTQ1F1WXE0aDRWeUxVSVUyWE1QS1V3OGF2cWhuM0pxbGx4WUJuOE9XdENiRS9BWTdLU2lMWHk5V1BYcHRhdFpyeTV4T0x1SzYxZCtsSzJrdTlVc2xVcTY5b3BIZHhNZ3VqV0EvOUV1SkRINEVEblJ0c0lDT1oyZmxibEllQng4VU5zemExWjJ3NlIxUmtWQVN3YVZDL3JXOVpJaXhkTjdyQzUxQU1qU2YzUnBUc0cvT1Y2blNFcHJNa2hVWWRoSFdSb09XZk8rUGJmZGE1Sm85SHMyeHZENE43L2hPSjQzdC8wV0o1bng3NkNxMTNHcGlFYmlIbXZIQU1jS3R4aHVBS2M4NEk0PTwvWDUwOUNlcnRpZmljYXRlPjwvWDUwOURhdGE+PC9LZXlJbmZvPjwvU2lnbmF0dXJlPg0KICA8c2FtbDI6U3ViamVjdD4NCiAgICA8c2FtbDI6TmFtZUlEIEZvcm1hdD0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6MS4xOm5hbWVpZC1mb3JtYXQ6dW5zcGVjaWZpZWQiPnVybjpjb2xsYWI6cGVyc29uOmluc3RpdHV0aW9uLWEubmw6cGlldGVyLWExPC9zYW1sMjpOYW1lSUQ+DQogIDwvc2FtbDI6U3ViamVjdD4NCiAgPHNhbWwycDpSZXF1ZXN0ZWRBdXRobkNvbnRleHQgQ29tcGFyaXNvbj0iZXhhY3QiPg0KICAgIDxzYW1sMjpBdXRobkNvbnRleHRDbGFzc1JlZj5odHRwOi8vdGVzdDIuc3VyZmNvbmV4dC5ubC9hc3N1cmFuY2Uvc2ZvLWxldmVsMjwvc2FtbDI6QXV0aG5Db250ZXh0Q2xhc3NSZWY+DQogIDwvc2FtbDJwOlJlcXVlc3RlZEF1dGhuQ29udGV4dD4NCjwvc2FtbDJwOkF1dGhuUmVxdWVzdD4='
         );
+        if (! isset($context['debugsp:AssertionConsumerServiceURL']) ) {
+            // Add some GET request parameters to the ACL URL. The IdP that can work with the ADFS SFO endpoint must use
+            // this exact URL so these parameters are returned. We do not actually verify this currently
+            $sspDebugSPACSURL = SimpleSAML\Module::getModuleURL('debugsp/acs/');
+            $sp=$_REQUEST['sp'];
+            $context['debugsp:AssertionConsumerServiceURL'] = $sspDebugSPACSURL.$sp.'?SAMLRequest=request_that_must_be_kept&Context=context_value_that_must_be_kept';
+        }
     }
-
 
     // login
     $as->login( $context );
@@ -282,7 +301,7 @@ if ( $bIsAuthenticated ) {
     $attributes = $as->getAttributes();
 
     /** @var $session SimpleSAML_Session */
-    $requestedLOA = htmlentities($session->getData('string', 'RequiredAuthnContextClassRef'));
+    $requestedLOA = htmlentities($session->getData('string', 'RequiredAuthnContextClassRef') ?? '' );
     $IdPEntityID = htmlentities($as->getAuthData('saml:sp:IdP'));
     $sessionIndex = htmlentities($as->getAuthData('saml:sp:SessionIndex'));
     $authState = $session->getAuthState($sp);
@@ -482,7 +501,7 @@ $commonIDPs_datalist=
 html;
 
 $sspACSURL = SimpleSAML\Module::getModuleURL('saml/sp/saml2-acs.php/');
-$sspDebugSPACSURL = SimpleSAML\Module::getModuleURL('DebugSP/sp/saml2-acs.php/');
+$sspDebugSPACSURL = SimpleSAML\Module::getModuleURL('debugsp/acs/');
 
 $emulateADFSchecked = isset($_REQUEST['emulateadfs']) && $_REQUEST['emulateadfs'] == 'true' ? ' checked' : '';
 $forceAuthnChecked = isset($_REQUEST['forceauthn']) && $_REQUEST['forceauthn'] == 'true' ? ' checked' : '';
@@ -530,7 +549,7 @@ echo <<<html
                    </datalist>
                </p>
                <p>
-                   <label title="If selected two extra POST variables 'AuthMethod' and 'Context' are added to the AuthnRequest. Only has an effect when the HTTP-POST binding is used.">Emulate ADFS:</label><input type="checkbox" name="emulateadfs" value="true"{$emulateADFSchecked} /><br />
+                   <label title="If selected two extra POST variables 'AuthMethod' and 'Context' are added to the AuthnRequest and the HTTP-POST binding is used. Note: Request LOA and Subject should be specified as well to make vailid SFO request to the Stepup-Gateway">Emulate SFO ADFS extension:</label><input type="checkbox" name="emulateadfs" value="true"{$emulateADFSchecked} /><br />
                </p>
                 
                <p>

--- a/docker/sspwww/sp.php
+++ b/docker/sspwww/sp.php
@@ -388,11 +388,12 @@ HTML_select('Request LOA: ', 'loa',
     array(
         "" => "None",
         "1" => "1",
+        "1.5" => "1.5",
         "2" => "2",
         "3" => "3",
     ),
     $loa,
-"Select the level of assurance to include in the AuthnContextClassRef in the AuthnRequest. The value depends on the selected IdP and LoA and is only added when the IdP supports it."
+"Select the level of assurance to include in the AuthnContextClassRef in the AuthnRequest. The value depends on the selected IdP and the selectded LoA and is only added when the IdP supports it."
 );
 
 echo <<<html
@@ -522,7 +523,9 @@ echo <<<html
                <p>
                    <label title="Specify the value of a NameID to put in a Subject element in the AuthnRequest. If specified a NameID of type 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified' is added to the AuthnRequest.">Subject:</label><input type="text" name="subject" list="commonSubjects" value="{$subject}" size="80" />
                    <datalist id="commonSubjects">
-                        <option value="urn:collab:person:stepup.example.com:admin" />
+                        <option value="urn:collab:person:dev.openconext.local:admin" />
+                        <option value="urn:collab:person:institution-a.example.com:jane-a1" />
+                        <option value="urn:collab:person:institution-a.example.com:joe-a1" />
                         <option value="urn:collab:person:institution-a.example.com:" />
                         <option value="urn:collab:person:institution-b.example.com:" />
                         <option value="urn:collab:person:institution-c.example.com:" />


### PR DESCRIPTION
OpenConext-devssp was based on the SimpleSAMLphp setup with SPs and IdPs for integration testing that was part of of the dev role in Stepup-Deploy (https://github.com/OpenConext/Stepup-Deploy/tree/develop/roles/dev)

However with the upgrade to a newer PHP and SimpleSAMLphp version many things broke. Most things have been fixed, except notably the ability to emulate the the way the SURF ADFS MFA extension call the SFO endpoint of the Stepup-Gateway. Because doing this requires manipulation of the SAML Request and Response beyond what is possible in SimpleSAMLphp, a module is required for that. 

This PR adds a debugsp module that does this, together with some scripts that help with debugging and developing this.

